### PR TITLE
Replace first the path of the project and then replace work

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/ParseInfoProcess.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/ParseInfoProcess.kt
@@ -10,7 +10,7 @@ class ParseInfoProcess(private val rootDirPath: String) {
             val executor = processInfo.split("Gradle Test Executor ")[1].split("'")[0]
             val task = processInfo
                 .split("-Dorg.gradle.internal.worker.tmpdir=")[1].split(",")[0].replace("/build/tmp", "")
-                .replace("/work", "").replace(rootDirPath, "")
+                .replace(rootDirPath, "").replace("/work", "")
                 .replace("/", ":").split("\n")[0]
             val heap = processInfo.split("-Xmx")[1].split(",")[0]
             if (executor.isNotEmpty() && task.isNotEmpty() && heap.isNotEmpty()) {

--- a/src/test/kotlin/io/github/cdsap/testprocess/ParseInfoProcessTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/ParseInfoProcessTest.kt
@@ -59,12 +59,12 @@ class ParseInfoProcessTest {
 
     @Test
     fun correctFormatParseTestProcess(){
-        val parseInfoProcess = ParseInfoProcess("PATH")
+        val parseInfoProcess = ParseInfoProcess("/home/runner/work/nowinandroid/nowinandroid")
         val info = """
             user: Optional[inakivillar],
             cmd: /.asdf/installs/java/liberica-11.0.15.1+2/bin/java,
             args: [-Djava.awt.headless=true,
-            -Dorg.gradle.internal.worker.tmpdir=PATH/feature/author/build/tmp/testProdReleaseUnitTest/work,
+            -Dorg.gradle.internal.worker.tmpdir=/home/runner/work/nowinandroid/nowinandroid/feature/author/build/tmp/testProdReleaseUnitTest/work,
             -Dorg.gradle.native=false, -javaagent:build/tmp/expandedArchives/org.jacoco.agent-0.8.7.jar_3a83c50b4a016f281c4e9f3500d16b55/jacocoagent.jar=destfile=build/jacoco/testProdReleaseUnitTest.exec,
             append=true,excludes=jdk.internal .*,inclnolocationclasses=true,dumponexit=true,
             output=file,jmx=false, @ /.gradle/.tmp/gradle-worker-classpath909835543043326786txt,


### PR DESCRIPTION
In environments with paths like:
`/home/runner/work/nowinandroid/nowinandroid`
the parsing of the task associated with the `tmpDir` was generating incorrect task names:
```
 :home:runner:nowinandroid:nowinandroid:feature:foryou:testDemoReleaseUnitTest
```

This PR applies first the replacement of the path in the tmpDir for later replace the suffix `work`