### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Apply the plugin in your main `settings.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("io.github.cdsap.testprocess") version "1.0.1"
+    id("io.github.cdsap.testprocess") version "2.0.0"
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "1.0.1"
+version = "2.0.0"
 
 java {
     toolchain {

--- a/e2e/consumer/settings.gradle.kts
+++ b/e2e/consumer/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.github.cdsap.testprocess") version "1.0.1"
+    id("io.github.cdsap.testprocess") version "2.0.0"
 }
 
 rootProject.name = "info-test-process-e2e-consumer"


### PR DESCRIPTION
## Summary

- Bumps the plugin version from **1.0.1 → 2.0.0**
- Updates the version pin in `README.md`'s plugins-block snippet
- Updates `e2e/consumer/settings.gradle.kts` so the on-PR e2e jobs resolve the new artifact from mavenLocal

This is the version-tag PR for the agent-based rework merged in #64.

## Why MAJOR

Every consumer-visible surface changed shape:

| Surface | 1.x | 2.0 |
|---|---|---|
| Build Scan custom value keys | `Test-Process`, `Test-Process-process-info-<pid>`, `Test-Process-Stats`, `Test-Process-processes-by-task-…` | `testProcess.workers.count`, `testProcess.worker.<pid>`, `testProcess.cpuCoresAvg.max`, … |
| Per-worker value format | bracketed string `[executor:…, task:…, xmx:…, usage:0.02Gb, …]` | JSON object with named fields |
| Persisted `statsTestTasks.json` shape | flat `Map<String,String>` mirroring custom-value keys | nested `{ summary, byTask, workers, tags }` |
| Internal: `PersistedState` fields | `jstatResults: Map<Long,String>` | `runtimeStats: Map<Long, WorkerRuntimeStats>` |
| Internal: `Stats` fields | `jstatCalls`, `jstatErrors` | `statsSnapshotsCaptured`, `statsSnapshotsMissing` |
| Min test-worker JDK | implicit | **17+** (agent bytecode) |
| External `jstat` dependency | required | removed (pure JMX) |

Even passive consumers (DRV dashboards / alerts on the old key names) silently break — that's the canonical MAJOR-bump trigger under semver.

## Test plan

- [x] `./gradlew test` (28/28 passing locally on Gradle 8.14.3 + 9.1.0)
- [x] Local publish + consumer at 2.0.0: CC stored on first build, reused on second
- [x] CI re-runs the e2e jobs from #64 against the bumped artifact

## After merge

Tag `v2.0.0` on `main` so the Gradle Plugin Portal picks it up:
```
git tag v2.0.0 <merge-commit-sha>
git push origin v2.0.0
```

(Or whatever your normal release workflow is — I left tagging out of this PR so the version-bump commit is small.)