### PR TITLE
2.1.0 — Relocate plugin scratch under build/info-test-process/

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,18 +71,19 @@ jobs:
               shell: bash
               run: |
                   set -euo pipefail
-                  test -f .info-test-process/agent.jar \
+                  scratch=build/info-test-process
+                  test -f "$scratch/agent.jar" \
                       || { echo "::error::agent jar not extracted"; exit 1; }
-                  stats_files=$(ls .info-test-process/workers/*.stats.json 2>/dev/null | wc -l | tr -d ' ')
+                  stats_files=$(ls $scratch/workers/*.stats.json 2>/dev/null | wc -l | tr -d ' ')
                   [ "$stats_files" -ge 1 ] \
                       || { echo "::error::no worker stats files produced"; exit 1; }
-                  identity_files=$(ls .info-test-process/workers/*.json 2>/dev/null | grep -v '\.stats\.json' | wc -l | tr -d ' ')
+                  identity_files=$(ls $scratch/workers/*.json 2>/dev/null | grep -v '\.stats\.json' | wc -l | tr -d ' ')
                   [ "$identity_files" -eq "$stats_files" ] \
                       || { echo "::error::identity ($identity_files) != stats ($stats_files) — orphans detected"; exit 1; }
-                  test -f statsTestTasks.json \
+                  test -f "$scratch/statsTestTasks.json" \
                       || { echo "::error::statsTestTasks.json not generated"; exit 1; }
                   for key in summary byTask workers tags; do
-                      grep -q "\"$key\"" statsTestTasks.json \
+                      grep -q "\"$key\"" "$scratch/statsTestTasks.json" \
                           || { echo "::error::statsTestTasks.json missing \"$key\""; exit 1; }
                   done
                   echo "OK — agent loaded $stats_files worker(s), identity/stats files balanced, output JSON contains summary/byTask/workers/tags"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Apply the plugin in your main `settings.gradle(.kts)`:
 
 ```kotlin
 plugins {
-    id("io.github.cdsap.testprocess") version "2.0.0"
+    id("io.github.cdsap.testprocess") version "2.1.0"
 }
 ```
 
@@ -101,8 +101,10 @@ Categorical filters for fast slicing in DRV. Fired automatically when thresholds
 
 ### File output (no Develocity)
 
-Without Develocity, the same data is written to `${rootDir}/statsTestTasks.json` as
-a single nested document with `summary` / `byTask` / `workers` / `tags`:
+Without Develocity, the same data is written to
+`${rootDir}/build/info-test-process/statsTestTasks.json` as a single nested document
+with `summary` / `byTask` / `workers` / `tags` (the file lives under `build/` so
+it's covered by every project's existing `.gitignore` and wiped by `./gradlew clean`):
 
 ```json
 {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "2.0.0"
+version = "2.1.0"
 
 java {
     toolchain {

--- a/e2e/consumer/.gitignore
+++ b/e2e/consumer/.gitignore
@@ -1,5 +1,2 @@
 .gradle/
 build/
-.info-test-process/
-statsTestTasks.txt
-statsTestTasks.json

--- a/e2e/consumer/settings.gradle.kts
+++ b/e2e/consumer/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.github.cdsap.testprocess") version "2.0.0"
+    id("io.github.cdsap.testprocess") version "2.1.0"
 }
 
 rootProject.name = "info-test-process-e2e-consumer"

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -11,57 +11,73 @@ import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.kotlin.dsl.of
 import org.gradle.kotlin.dsl.withType
-import java.io.File
+import org.gradle.process.CommandLineArgumentProvider
 
 class InfoTestProcessPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
         val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
-        // Compute paths only; do NOT touch the filesystem here — that would invalidate the
-        // configuration cache between runs. The directories are created lazily by the
-        // BuildService at execution time.
-        val workDir = File("${target.rootDir}/.info-test-process")
-        val agentJar = File(workDir, "agent.jar")
-        val registryDir = File(workDir, "workers")
 
-        val service = target.gradle.sharedServices.registerIfAbsent(
-            "statsBuildService", StatsBuildService::class.java
-        ) {
-            parameters.path = target.providers.provider { File("${target.layout.rootDirectory}/statsTestTasks.txt") }
-            parameters.pathJson = target.providers.provider { File("${target.layout.rootDirectory}/statsTestTasks.json") }
-            parameters.registryDir = target.providers.provider { registryDir }
-            parameters.agentJar = target.providers.provider { agentJar }
-            parameters.develocity = target.providers.provider { develocityConfiguration != null }
-        }
+        // Defer to the root Project so we can use ProjectLayout.getBuildDirectory()
+        // (https://docs.gradle.org/current/dsl/org.gradle.api.file.ProjectLayout.html) —
+        // a DirectoryProperty that respects any custom buildDirectory configuration and
+        // composes through the typed Directory / RegularFile / Provider API end-to-end.
+        // rootProject {} runs once after the root project is instantiated, before any
+        // project (including the root) is configured, so the service and the per-Test
+        // wiring are still in place before any test task is reached.
+        target.gradle.rootProject {
+            val workDir = layout.buildDirectory.dir("info-test-process")
+            val agentJar = workDir.map { it.file("agent.jar") }
+            val registryDir = workDir.map { it.dir("workers") }
+            val persistedTxt = workDir.map { it.file("statsTestTasks.txt") }
+            val persistedJson = workDir.map { it.file("statsTestTasks.json") }
 
-        val provider = target.providers.of(PersistedDeserializationValueSource::class) {
-            parameters.file.set(File("${target.layout.rootDirectory}/statsTestTasks.txt"))
-        }
-
-        target.gradle.beforeProject {
-            this.tasks.withType<Test>().configureEach {
-                usesService(service)
-                val testPath = this.path
-                jvmArgs("-D${ParseInfoProcess.TASK_PROPERTY}=$testPath")
-                jvmArgs("-javaagent:${agentJar.absolutePath}=${registryDir.absolutePath}")
-                doFirst {
-                    // Ensure the BuildService is initialized — its init block extracts the agent
-                    // jar and resets the registry directory before any worker forks.
-                    service.get()
-                }
-                addTestListener(object : TestListener {
-                    override fun beforeSuite(suite: TestDescriptor?) {
-                        if (isGradleExecutor(suite?.name)) {
-                            service.get().stats.totalProcesses++
-                        }
-                    }
-                    override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {}
-                    override fun beforeTest(testDescriptor: TestDescriptor?) {}
-                    override fun afterTest(testDescriptor: TestDescriptor?, result: TestResult?) {}
-                })
+            val service = gradle.sharedServices.registerIfAbsent(
+                "statsBuildService", StatsBuildService::class.java
+            ) {
+                parameters.path = persistedTxt.map { it.asFile }
+                parameters.pathJson = persistedJson.map { it.asFile }
+                parameters.registryDir = registryDir.map { it.asFile }
+                parameters.agentJar = agentJar.map { it.asFile }
+                parameters.develocity = providers.provider { develocityConfiguration != null }
             }
-        }
-        if (develocityConfiguration != null) {
-            BuildScanReport().develocityBuildScanReporting(develocityConfiguration, provider)
+
+            val persistedStateProvider = providers.of(PersistedDeserializationValueSource::class) {
+                parameters.file.set(persistedTxt)
+            }
+            if (develocityConfiguration != null) {
+                BuildScanReport().develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
+            }
+
+            gradle.beforeProject {
+                tasks.withType<Test>().configureEach {
+                    usesService(service)
+                    val testPath = path
+                    // Use a CommandLineArgumentProvider so the paths resolve at task
+                    // execution time — after any custom buildDirectory configuration in
+                    // the root build script has been applied.
+                    jvmArgumentProviders.add(CommandLineArgumentProvider {
+                        listOf(
+                            "-D${ParseInfoProcess.TASK_PROPERTY}=$testPath",
+                            "-javaagent:${agentJar.get().asFile.absolutePath}=${registryDir.get().asFile.absolutePath}"
+                        )
+                    })
+                    doFirst {
+                        // Materializing the service forces its init block, which extracts
+                        // the agent jar and resets the registry directory before workers fork.
+                        service.get()
+                    }
+                    addTestListener(object : TestListener {
+                        override fun beforeSuite(suite: TestDescriptor?) {
+                            if (isGradleExecutor(suite?.name)) {
+                                service.get().stats.totalProcesses++
+                            }
+                        }
+                        override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {}
+                        override fun beforeTest(testDescriptor: TestDescriptor?) {}
+                        override fun afterTest(testDescriptor: TestDescriptor?, result: TestResult?) {}
+                    })
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
@@ -74,7 +74,7 @@ class IntegrationNoDvTest {
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
-            val firstJson = File("${testProjectDir.root}/statsTestTasks.json")
+            val firstJson = File("${testProjectDir.root}/build/info-test-process/statsTestTasks.json")
             assertTrue(firstJson.exists())
             val body = firstJson.readText()
             assertTrue(body.contains("\"summary\""))


### PR DESCRIPTION
## Summary

The plugin's scratch directory and the non-Develocity output file used to land at the root project's working directory:

```
.info-test-process/
  agent.jar
  workers/
    {pid}.json
    {pid}.stats.json
statsTestTasks.json   (when no Develocity)
```

…which every consumer had to add to their `.gitignore`. The plugin now writes everything under `${rootProject.layout.buildDirectory}/info-test-process/`:

```
build/info-test-process/
  agent.jar
  workers/
    {pid}.json
    {pid}.stats.json
  statsTestTasks.txt    (intermediate, for the Develocity path)
  statsTestTasks.json   (when no Develocity)
```

That location is:

- covered by every Gradle project's existing `.gitignore` (`build/`)
- wiped by `./gradlew clean`
- respects any custom `buildDirectory` configuration

## Idiomatic API change

Switched from `File("${target.rootDir}/…")` string-interpolation to the typed [`ProjectLayout`](https://docs.gradle.org/current/dsl/org.gradle.api.file.ProjectLayout.html) API end-to-end:

- Setup deferred to `gradle.rootProject { … }` so we have access to `layout.buildDirectory` (a `DirectoryProperty`)
- Path composition uses `Directory.dir(…)` / `Directory.file(…)` / `Provider<RegularFile>`
- Test task wiring uses a `CommandLineArgumentProvider` so the agent-jar path resolves at task execution time, after any custom `buildDirectory` configuration in the root build script has been applied

## Bump

**2.0.0 → 2.1.0** (minor). The documented non-Develocity file output path changes:

- `${rootDir}/statsTestTasks.json` → `${rootDir}/build/info-test-process/statsTestTasks.json`

Consumers who scripted around the old path need to update.

## Test plan

- [x] `./gradlew test` — 28/28 pass
- [x] Local consumer build: CC stored on first build, reused on second, root directory now clean (no untracked plugin files)
- [x] Agent + stats files land under `e2e/consumer/build/info-test-process/`
- [x] `e2e-cc` and `e2e-isolated-projects` GHA jobs updated to look at the new path