### PR TITLE
Fix Isolated Projects failure on Gradle 9.7+

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,18 +53,18 @@ jobs:
               shell: bash
               run: |
                   set -euo pipefail
-                  out=$(../../gradlew test --configuration-cache 2>&1)
-                  echo "$out"
-                  echo "$out" | grep -q "Configuration cache entry stored" \
+                  log="${RUNNER_TEMP:-/tmp}/cc-first.log"
+                  ../../gradlew test --configuration-cache 2>&1 | tee "$log"
+                  grep -q "Configuration cache entry stored" "$log" \
                       || { echo "::error::First build did not store CC"; exit 1; }
             - name: Second build — expect "Configuration cache entry reused"
               working-directory: e2e/consumer
               shell: bash
               run: |
                   set -euo pipefail
-                  out=$(../../gradlew test --configuration-cache 2>&1)
-                  echo "$out"
-                  echo "$out" | grep -q "Configuration cache entry reused" \
+                  log="${RUNNER_TEMP:-/tmp}/cc-second.log"
+                  ../../gradlew test --configuration-cache 2>&1 | tee "$log"
+                  grep -q "Configuration cache entry reused" "$log" \
                       || { echo "::error::Second build did not reuse CC"; exit 1; }
             - name: Verify plugin produced agent + stats artifacts
               working-directory: e2e/consumer
@@ -110,16 +110,16 @@ jobs:
               shell: bash
               run: |
                   set -euo pipefail
-                  out=$(../../gradlew test -Dorg.gradle.unsafe.isolated-projects=true 2>&1)
-                  echo "$out"
-                  echo "$out" | grep -q "Configuration cache entry stored" \
+                  log="${RUNNER_TEMP:-/tmp}/ip-first.log"
+                  ../../gradlew test -Dorg.gradle.unsafe.isolated-projects=true 2>&1 | tee "$log"
+                  grep -q "Configuration cache entry stored" "$log" \
                       || { echo "::error::IP first build did not store CC"; exit 1; }
             - name: Second build with Isolated Projects — reuse
               working-directory: e2e/consumer
               shell: bash
               run: |
                   set -euo pipefail
-                  out=$(../../gradlew test -Dorg.gradle.unsafe.isolated-projects=true 2>&1)
-                  echo "$out"
-                  echo "$out" | grep -q "Configuration cache entry reused" \
+                  log="${RUNNER_TEMP:-/tmp}/ip-second.log"
+                  ../../gradlew test -Dorg.gradle.unsafe.isolated-projects=true 2>&1 | tee "$log"
+                  grep -q "Configuration cache entry reused" "$log" \
                       || { echo "::error::IP second build did not reuse CC"; exit 1; }

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -4,7 +4,11 @@ import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.testprocess.report.BuildScanReport
 import io.github.cdsap.testprocess.service.StatsBuildService
 import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
 import org.gradle.api.initialization.Settings
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
@@ -17,13 +21,21 @@ class InfoTestProcessPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
         val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
 
+        // Populated by the rootProject {} action below, which runs when the root project is
+        // instantiated — before any project (including the root) is configured, so the
+        // per-Test wiring is always in place before a test task is reached.
+        var wireProject: (Project) -> Unit = {}
+
+        // Registered from Settings scope, not from inside rootProject {}: Gradle.beforeProject
+        // is a Gradle-wide (cross-project) hook, and since Isolated Projects graduated to
+        // incubating in Gradle 9.7 reaching for it from a project fails the build with
+        // "Project ':' cannot access Gradle.beforeProject".
+        target.gradle.beforeProject { wireProject(this) }
+
         // Defer to the root Project so we can use ProjectLayout.getBuildDirectory()
         // (https://docs.gradle.org/current/dsl/org.gradle.api.file.ProjectLayout.html) —
         // a DirectoryProperty that respects any custom buildDirectory configuration and
         // composes through the typed Directory / RegularFile / Provider API end-to-end.
-        // rootProject {} runs once after the root project is instantiated, before any
-        // project (including the root) is configured, so the service and the per-Test
-        // wiring are still in place before any test task is reached.
         target.gradle.rootProject {
             val workDir = layout.buildDirectory.dir("info-test-process")
             val agentJar = workDir.map { it.file("agent.jar") }
@@ -48,36 +60,44 @@ class InfoTestProcessPlugin : Plugin<Settings> {
                 BuildScanReport().develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
             }
 
-            gradle.beforeProject {
-                tasks.withType<Test>().configureEach {
-                    usesService(service)
-                    val testPath = path
-                    // Use a CommandLineArgumentProvider so the paths resolve at task
-                    // execution time — after any custom buildDirectory configuration in
-                    // the root build script has been applied.
-                    jvmArgumentProviders.add(CommandLineArgumentProvider {
-                        listOf(
-                            "-D${ParseInfoProcess.TASK_PROPERTY}=$testPath",
-                            "-javaagent:${agentJar.get().asFile.absolutePath}=${registryDir.get().asFile.absolutePath}"
-                        )
-                    })
-                    doFirst {
-                        // Materializing the service forces its init block, which extracts
-                        // the agent jar and resets the registry directory before workers fork.
-                        service.get()
-                    }
-                    addTestListener(object : TestListener {
-                        override fun beforeSuite(suite: TestDescriptor?) {
-                            if (isGradleExecutor(suite?.name)) {
-                                service.get().stats.totalProcesses++
-                            }
-                        }
-                        override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {}
-                        override fun beforeTest(testDescriptor: TestDescriptor?) {}
-                        override fun afterTest(testDescriptor: TestDescriptor?, result: TestResult?) {}
-                    })
-                }
+            wireProject = { project ->
+                project.configureTestTasks(service, agentJar, registryDir)
             }
+        }
+    }
+
+    private fun Project.configureTestTasks(
+        service: Provider<StatsBuildService>,
+        agentJar: Provider<RegularFile>,
+        registryDir: Provider<Directory>
+    ) {
+        tasks.withType<Test>().configureEach {
+            usesService(service)
+            val testPath = path
+            // Use a CommandLineArgumentProvider so the paths resolve at task
+            // execution time — after any custom buildDirectory configuration in
+            // the root build script has been applied.
+            jvmArgumentProviders.add(CommandLineArgumentProvider {
+                listOf(
+                    "-D${ParseInfoProcess.TASK_PROPERTY}=$testPath",
+                    "-javaagent:${agentJar.get().asFile.absolutePath}=${registryDir.get().asFile.absolutePath}"
+                )
+            })
+            doFirst {
+                // Materializing the service forces its init block, which extracts
+                // the agent jar and resets the registry directory before workers fork.
+                service.get()
+            }
+            addTestListener(object : TestListener {
+                override fun beforeSuite(suite: TestDescriptor?) {
+                    if (isGradleExecutor(suite?.name)) {
+                        service.get().stats.totalProcesses++
+                    }
+                }
+                override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {}
+                override fun beforeTest(testDescriptor: TestDescriptor?) {}
+                override fun afterTest(testDescriptor: TestDescriptor?, result: TestResult?) {}
+            })
         }
     }
 

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
@@ -19,7 +19,7 @@ class IntegrationNoDvTest {
 
         createProject()
 
-        listOf("8.14.3", "9.1.0").forEach {
+        listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments("test", "--configuration-cache")
@@ -43,7 +43,7 @@ class IntegrationNoDvTest {
     fun testPluginIsCompatibleWithProjectIsolation() {
 
         createProject()
-        listOf("8.14.3", "9.1.0").forEach {
+        listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments("test", "-Dorg.gradle.unsafe.isolated-projects=true")
@@ -67,7 +67,7 @@ class IntegrationNoDvTest {
 
         createProject()
 
-        listOf("8.14.3", "9.1.0").forEach {
+        listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments("test", "--configuration-cache")

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationTest.kt
@@ -52,7 +52,7 @@ class InfoTestProcessPluginTest {
                 }
             """.trimIndent()
         )
-        listOf("8.14.3", "9.1.0").forEach {
+        listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments("test", "--configuration-cache")


### PR DESCRIPTION
## Why

`e2e-isolated-projects` fails on the Gradle 9.7.1 upgrade PR (#70). The job log only shows `exit code 1`, because the step captured Gradle's output into `out=$(...)` under `set -e` and died before echoing it. The real error is:

```
1 problem was found storing the configuration cache.
- Plugin 'io.github.cdsap.testprocess': Project ':' cannot access Gradle.beforeProject
```

Isolated Projects graduated to incubating in Gradle 9.7 and now rejects `Gradle.beforeProject` when it is reached from project scope. The plugin registered that hook from inside `gradle.rootProject { }`, so any consumer building with `-Dorg.gradle.unsafe.isolated-projects=true` fails on 9.7.x.

Reproduced against the branch's own history — same plugin code throughout:

| Gradle on `renovate/gradle-9.x` | `e2e-isolated-projects` |
| --- | --- |
| 9.6.1 (`67fec54`) | pass |
| 9.7.0 (`2330764`) | fail |
| 9.7.1 (`96671c4`) | fail |

`e2e-cc` stays green because plain configuration cache does not enforce project isolation.

## What changed

- **`InfoTestProcessPlugin`** — register `beforeProject` from Settings scope and install the per-`Test` wiring through it once the root project is available. Behaviour is unchanged: paths still derive from the root project's `ProjectLayout.buildDirectory`, so a custom build directory is still honoured.

  `gradle.lifecycle.beforeProject` is the natural replacement, but registering it from inside `rootProject { }` is a **no-op** on 8.14.x/9.1.x — the root project already exists by then — which silently disables the plugin (no `agent.jar`, no `statsTestTasks.json`). Hence the plain hook, registered before any project is created.

- **Tests** — added `9.7.1` to the TestKit version matrix. `testPluginIsCompatibleWithProjectIsolation` fails on `9.7.1` without the plugin change and passes with it, so the regression is now covered.

- **CI** — the four e2e steps stream Gradle output through `tee` instead of swallowing it in a command substitution, so the next failure of this kind is diagnosable from the job log.

## Verification

Local runs on a single-project and a multi-project consumer, `4.13.2` JUnit tests forking one worker each:

| Gradle | plain CC (store / reuse) | Isolated Projects (store / reuse) | artifacts |
| --- | --- | --- | --- |
| 8.14.3 | pass | pass | `agent.jar`, `statsTestTasks.json`, balanced `workers/*.json` + `*.stats.json` |
| 9.1.0 | pass | pass | same |
| 9.6.0 | pass | pass | same |
| 9.7.1 | pass | pass | same |

Multi-project under Isolated Projects on 9.7.1 aggregates both subprojects at the root: `byTask` = `[":a:test", ":b:test"]`, `summary.workers.count` = 2, `snapshotsMissing` = 0.

`./gradlew test` is green, including the new 9.7.1 TestKit runs.

Once this is on `main`, Renovate rebases #70 and the Gradle 9.7.1 upgrade should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)