### PR TITLE
fix: refactor worker state collection to isolate gradle service orchestr

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
@@ -1,0 +1,23 @@
+package io.github.cdsap.testprocess.agent
+
+import io.github.cdsap.testprocess.model.PersistedState
+import io.github.cdsap.testprocess.model.Stats
+import io.github.cdsap.testprocess.model.TestProcess
+import java.io.File
+
+object WorkerStateCollector {
+    fun collect(
+        registryDir: File,
+        processes: MutableMap<Long, TestProcess>,
+        stats: Stats
+    ): PersistedState {
+        WorkerRegistry.read(registryDir).forEach { entry ->
+            processes.putIfAbsent(entry.pid, entry.toTestProcess())
+        }
+        val runtimeStats: Map<Long, WorkerRuntimeStats> =
+            WorkerRegistry.readStats(registryDir).associateBy { it.pid }
+        stats.statsSnapshotsCaptured = runtimeStats.size
+        stats.statsSnapshotsMissing = processes.keys.count { it !in runtimeStats }
+        return PersistedState(processes, runtimeStats, stats)
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
@@ -1,7 +1,7 @@
 package io.github.cdsap.testprocess.service
 
 import io.github.cdsap.testprocess.agent.WorkerRegistry
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
+import io.github.cdsap.testprocess.agent.WorkerStateCollector
 import io.github.cdsap.testprocess.model.PersistedState
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
@@ -42,14 +42,7 @@ abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, A
 
     override fun close() {
         val registry = parameters.registryDir.get()
-        WorkerRegistry.read(registry).forEach { entry ->
-            processes.putIfAbsent(entry.pid, entry.toTestProcess())
-        }
-        val runtimeStats: Map<Long, WorkerRuntimeStats> = WorkerRegistry.readStats(registry).associateBy { it.pid }
-        stats.statsSnapshotsCaptured = runtimeStats.size
-        stats.statsSnapshotsMissing = processes.keys.count { it !in runtimeStats }
-
-        val payload = PersistedState(processes, runtimeStats, stats)
+        val payload = WorkerStateCollector.collect(registry, processes, stats)
         if (parameters.develocity.get()) {
             val output = parameters.path.get()
             output.parentFile?.mkdirs()
@@ -57,7 +50,12 @@ abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, A
         } else {
             val outputJson = parameters.pathJson.get()
             outputJson.parentFile?.mkdirs()
-            OutputReport(outputJson).extracted(processes, runtimeStats, stats, JsonValue())
+            OutputReport(outputJson).extracted(
+                payload.processes,
+                payload.runtimeStats,
+                payload.stats,
+                JsonValue()
+            )
         }
     }
 

--- a/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
@@ -1,0 +1,66 @@
+package io.github.cdsap.testprocess.agent
+
+import io.github.cdsap.testprocess.model.Stats
+import io.github.cdsap.testprocess.model.TestProcess
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WorkerStateCollectorTest {
+    @Rule
+    @JvmField
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun collectsStateWithCapturedAndMissingSnapshots() {
+        val dir = tmp.newFolder("workers")
+        File(dir, "10.json").writeText(
+            """{"pid":10,"task":":app:test","executor":"Gradle Test Executor 1","maxHeapBytes":536870912,"startMs":1,"args":[]}"""
+        )
+        File(dir, "10.stats.json").writeText(
+            """{"pid":10,"uptimeMs":12000,"cpuTimeMs":3400,"usedHeapBytes":104857600,"peakHeapBytes":209715200,"peakMetaspaceBytes":52428800,"maxHeapBytes":536870912,"gcCollections":4,"gcTimeMs":120,"gcType":"G1","jitTimeMs":850,"classesLoaded":4823,"peakThreads":18}"""
+        )
+        File(dir, "20.json").writeText(
+            """{"pid":20,"task":":lib:test","executor":"Gradle Test Executor 2","maxHeapBytes":1073741824,"startMs":2,"args":[]}"""
+        )
+        // Worker 20 has identity but no .stats.json snapshot.
+
+        val processes = mutableMapOf<Long, TestProcess>()
+        val stats = Stats(totalProcesses = 2)
+        val state = WorkerStateCollector.collect(dir, processes, stats)
+
+        assert(state.processes.size == 2)
+        assert(state.processes[10L]?.task == ":app:test")
+        assert(state.processes[10L]?.max == "512m")
+        assert(state.processes[20L]?.task == ":lib:test")
+        assert(state.processes[20L]?.max == "1g")
+
+        assert(state.runtimeStats.size == 1)
+        assert(state.runtimeStats[10L]?.gcType == "G1")
+        assert(20L !in state.runtimeStats)
+
+        assert(stats.statsSnapshotsCaptured == 1)
+        assert(stats.statsSnapshotsMissing == 1)
+        assert(state.stats === stats)
+        assert(state.processes === processes)
+    }
+
+    @Test
+    fun doesNotOverwriteExistingProcessEntries() {
+        val dir = tmp.newFolder("workers")
+        File(dir, "5.json").writeText(
+            """{"pid":5,"task":":from:registry","executor":"Registry Executor","maxHeapBytes":268435456,"startMs":1,"args":[]}"""
+        )
+        val existing = TestProcess(task = ":already:tracked", executor = "Existing", max = "256m")
+        val processes = mutableMapOf(5L to existing)
+        val stats = Stats()
+
+        val state = WorkerStateCollector.collect(dir, processes, stats)
+
+        assert(state.processes[5L] === existing)
+        assert(state.processes[5L]?.task == ":already:tracked")
+        assert(stats.statsSnapshotsCaptured == 0)
+        assert(stats.statsSnapshotsMissing == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/InfoTestProcess#75: Refactor worker state collection to isolate Gradle service orchestration

Fixes #75

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`