### PR TITLE
fix: refactor report projection to share worker aggregation

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
@@ -32,9 +32,10 @@ class BuildScanReport : Report {
     ) {
         if (processes.isEmpty()) return
 
-        val workers = processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }
-        val summary = Aggregator.summary(workers, stats)
-        val tags = Aggregator.tags(workers, stats)
+        val report = ReportDocument.from(processes, runtimeStats, stats)
+        val workers = report.workers
+        val summary = report.summary
+        val tags = report.tags
 
         // Flat numeric metrics — DRV indexes these as scalar columns.
         buildScanData.value("testProcess.workers.count", summary.workers.count.toString())

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
@@ -26,12 +26,12 @@ class OutputReport(val outputJson: File) : Report {
             outputJson.writeText("{}")
             return
         }
-        val workers = processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }
+        val report = ReportDocument.from(processes, runtimeStats, stats)
         val doc = OutputDocument(
-            summary = Aggregator.summary(workers, stats),
-            byTask = Aggregator.byTask(workers),
-            workers = workers,
-            tags = Aggregator.tags(workers, stats)
+            summary = report.summary,
+            byTask = report.byTask,
+            workers = report.workers,
+            tags = report.tags
         )
         outputJson.writeText(ReportJson.prettyJson.encodeToString(OutputDocument.serializer(), doc))
     }

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
@@ -15,6 +15,34 @@ interface Report {
     )
 }
 
+/**
+ * Shared report-domain projection from persisted worker state. Output adapters
+ * (Build Scan, JSON file) consume this instead of rebuilding workers / summary /
+ * byTask / tags themselves.
+ */
+internal data class ReportDocument(
+    val workers: List<WorkerProcessInfo>,
+    val summary: TestProcessSummary,
+    val byTask: Map<String, TaskSummary>,
+    val tags: List<String>
+) {
+    companion object {
+        fun from(
+            processes: Map<Long, TestProcess>,
+            runtimeStats: Map<Long, WorkerRuntimeStats>,
+            stats: Stats
+        ): ReportDocument {
+            val workers = processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }
+            return ReportDocument(
+                workers = workers,
+                summary = Aggregator.summary(workers, stats),
+                byTask = Aggregator.byTask(workers),
+                tags = Aggregator.tags(workers, stats)
+            )
+        }
+    }
+}
+
 @Serializable
 data class WorkerProcessInfo(
     val pid: Long,

--- a/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
@@ -1,6 +1,8 @@
 package io.github.cdsap.testprocess.report
 
+import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import io.github.cdsap.testprocess.model.Stats
+import io.github.cdsap.testprocess.model.TestProcess
 import org.junit.Test
 
 class AggregatorTest {
@@ -22,6 +24,70 @@ class AggregatorTest {
         jitSec = jitSec, classesLoaded = 3000L, peakThreads = 9,
         statsSnapshotMissing = statsSnapshotMissing
     )
+
+    @Test
+    fun reportDocumentFromComputesWorkersSummaryByTaskAndTags() {
+        val processes = mapOf(
+            10L to TestProcess(task = ":a:test", executor = "E1", max = "512m"),
+            20L to TestProcess(task = ":a:test", executor = "E2", max = "512m"),
+            30L to TestProcess(task = ":b:test", executor = "E3", max = "1g")
+        )
+        // Worker 10: hot CPU → cpu-heavy tag; worker 20: missing snapshot; worker 30: live, cooler.
+        val runtimeStats = mapOf(
+            10L to WorkerRuntimeStats(
+                pid = 10L,
+                uptimeMs = 10_000,
+                cpuTimeMs = 50_000, // 5.0 cores avg
+                usedHeapBytes = 100_000_000,
+                peakHeapBytes = 200_000_000,
+                peakMetaspaceBytes = 50_000_000,
+                maxHeapBytes = 536_870_912,
+                gcCollections = 4,
+                gcTimeMs = 120,
+                gcType = "G1",
+                jitTimeMs = 850,
+                classesLoaded = 4_823,
+                peakThreads = 18
+            ),
+            30L to WorkerRuntimeStats(
+                pid = 30L,
+                uptimeMs = 20_000,
+                cpuTimeMs = 2_000, // 0.1 cores avg
+                usedHeapBytes = 50_000_000,
+                peakHeapBytes = 80_000_000,
+                peakMetaspaceBytes = 20_000_000,
+                maxHeapBytes = 1_073_741_824,
+                gcCollections = 1,
+                gcTimeMs = 10,
+                gcType = "G1",
+                jitTimeMs = 100,
+                classesLoaded = 1_000,
+                peakThreads = 8
+            )
+        )
+        val stats = Stats(statsSnapshotsMissing = 1)
+
+        val report = ReportDocument.from(processes, runtimeStats, stats)
+
+        assert(report.workers.size == 3)
+        assert(report.workers.map { it.pid }.toSet() == setOf(10L, 20L, 30L))
+        val missing = report.workers.single { it.pid == 20L }
+        assert(missing.statsSnapshotMissing)
+        assert(missing.task == ":a:test")
+
+        assert(report.summary.workers.count == 3)
+        assert(report.summary.workers.tasksWith == 2)
+        assert(report.summary.workers.snapshotsMissing == 1)
+        assert(report.summary.cpuCoresAvgMax == 5.0)
+
+        // byTask only includes workers with a live stats snapshot
+        assert(report.byTask.keys == setOf(":a:test", ":b:test"))
+        assert(report.byTask[":a:test"]!!.workers == 1)
+        assert(report.byTask[":b:test"]!!.workers == 1)
+
+        assert(report.tags.contains("tests:cpu-heavy"))
+        assert(report.tags.contains("tests:no-snapshot"))
+    }
 
     @Test
     fun summaryComputesMaxesAndSums() {


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/InfoTestProcess#77: Refactor report projection to share worker aggregation

Fixes #77

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`