### PR TITLE
fix: refactor worker runtime stats to model boundary

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.testprocess.agent
 
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -27,23 +28,6 @@ data class WorkerRegistryEntry(
         else -> "${bytes}b"
     }
 }
-
-@Serializable
-data class WorkerRuntimeStats(
-    val pid: Long,
-    val uptimeMs: Long = 0,
-    val cpuTimeMs: Long = -1,
-    val usedHeapBytes: Long = 0,
-    val peakHeapBytes: Long = 0,
-    val peakMetaspaceBytes: Long = 0,
-    val maxHeapBytes: Long = 0,
-    val gcCollections: Long = 0,
-    val gcTimeMs: Long = 0,
-    val gcType: String = "Unknown",
-    val jitTimeMs: Long = -1,
-    val classesLoaded: Long = -1,
-    val peakThreads: Int = -1
-)
 
 object WorkerRegistry {
     private val json = Json { ignoreUnknownKeys = true }

--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.testprocess.agent
 import io.github.cdsap.testprocess.model.PersistedState
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import java.io.File
 
 object WorkerStateCollector {

--- a/src/main/kotlin/io/github/cdsap/testprocess/model/PersistedState.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/model/PersistedState.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.testprocess.model
 
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/src/main/kotlin/io/github/cdsap/testprocess/model/WorkerRuntimeStats.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/model/WorkerRuntimeStats.kt
@@ -1,0 +1,20 @@
+package io.github.cdsap.testprocess.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkerRuntimeStats(
+    val pid: Long,
+    val uptimeMs: Long = 0,
+    val cpuTimeMs: Long = -1,
+    val usedHeapBytes: Long = 0,
+    val peakHeapBytes: Long = 0,
+    val peakMetaspaceBytes: Long = 0,
+    val maxHeapBytes: Long = 0,
+    val gcCollections: Long = 0,
+    val gcTimeMs: Long = 0,
+    val gcType: String = "Unknown",
+    val jitTimeMs: Long = -1,
+    val classesLoaded: Long = -1,
+    val peakThreads: Int = -1
+)

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
@@ -1,10 +1,10 @@
 package io.github.cdsap.testprocess.report
 
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import io.github.cdsap.testprocess.model.PersistedState
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import org.gradle.api.provider.Provider
 
 class BuildScanReport : Report {

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
@@ -1,8 +1,8 @@
 package io.github.cdsap.testprocess.report
 
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import kotlinx.serialization.Serializable
 import java.io.File
 

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
@@ -1,8 +1,8 @@
 package io.github.cdsap.testprocess.report
 
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 

--- a/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.testprocess.agent
 
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -88,8 +89,27 @@ class WorkerRegistryTest {
             """{"pid":2,"uptimeMs":5000,"usedHeapBytes":1024,"maxHeapBytes":2048,"gcCollections":1,"gcTimeMs":10,"gcType":"PARALLEL"}"""
         )
         val s = WorkerRegistry.readStats(dir).single()
+        assert(WorkerRuntimeStats::class.java.`package`.name == "io.github.cdsap.testprocess.model")
         assert(s.cpuTimeMs == -1L)
         assert(s.jitTimeMs == -1L)
+        assert(s.classesLoaded == -1L)
         assert(s.peakThreads == -1)
+        assert(s.uptimeMs == 5000L)
+        assert(s.usedHeapBytes == 1024L)
+        assert(s.peakHeapBytes == 0L)
+        assert(s.peakMetaspaceBytes == 0L)
+        assert(s.gcType == "PARALLEL")
+    }
+
+    @Test
+    fun statsReaderIgnoresMalformedStatsFiles() {
+        val dir = tmp.newFolder("workers")
+        File(dir, "bad.stats.json").writeText("{not json")
+        File(dir, "3.stats.json").writeText(
+            """{"pid":3,"uptimeMs":1000,"cpuTimeMs":100,"usedHeapBytes":1,"peakHeapBytes":2,"peakMetaspaceBytes":3,"maxHeapBytes":4,"gcCollections":0,"gcTimeMs":0,"gcType":"G1","jitTimeMs":1,"classesLoaded":2,"peakThreads":3}"""
+        )
+        val stats = WorkerRegistry.readStats(dir)
+        assert(stats.size == 1)
+        assert(stats.single().pid == 3L)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
@@ -1,8 +1,8 @@
 package io.github.cdsap.testprocess.report
 
-import io.github.cdsap.testprocess.agent.WorkerRuntimeStats
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import org.junit.Test
 
 class AggregatorTest {


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/InfoTestProcess#79: Refactor worker runtime stats to model boundary

Fixes #79

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`