### PR TITLE
fix: refactor report worker projection to shared report input

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt
@@ -16,6 +16,19 @@ interface Report {
 }
 
 /**
+ * Shared report-ready worker view: projects collected process + runtime-stats
+ * maps into [WorkerProcessInfo] so Build Scan and file adapters share one
+ * behavior-preserving conversion (including missing-snapshot handling).
+ */
+internal object WorkerReportInput {
+    fun from(
+        processes: Map<Long, TestProcess>,
+        runtimeStats: Map<Long, WorkerRuntimeStats>
+    ): List<WorkerProcessInfo> =
+        processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }
+}
+
+/**
  * Shared report-domain projection from persisted worker state. Output adapters
  * (Build Scan, JSON file) consume this instead of rebuilding workers / summary /
  * byTask / tags themselves.
@@ -32,7 +45,7 @@ internal data class ReportDocument(
             runtimeStats: Map<Long, WorkerRuntimeStats>,
             stats: Stats
         ): ReportDocument {
-            val workers = processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }
+            val workers = WorkerReportInput.from(processes, runtimeStats)
             return ReportDocument(
                 workers = workers,
                 summary = Aggregator.summary(workers, stats),

--- a/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt
@@ -26,6 +26,58 @@ class AggregatorTest {
     )
 
     @Test
+    fun workerReportInputProjectsWorkersIncludingMissingRuntimeStats() {
+        val processes = mapOf(
+            10L to TestProcess(task = ":a:test", executor = "E1", max = "512m"),
+            20L to TestProcess(task = ":b:test", executor = "E2", max = "1g")
+        )
+        val runtimeStats = mapOf(
+            10L to WorkerRuntimeStats(
+                pid = 10L,
+                uptimeMs = 60_000,
+                cpuTimeMs = 30_000,
+                usedHeapBytes = 100_000_000,
+                peakHeapBytes = 200_000_000,
+                peakMetaspaceBytes = 50_000_000,
+                maxHeapBytes = 536_870_912,
+                gcCollections = 2,
+                gcTimeMs = 50,
+                gcType = "G1",
+                jitTimeMs = 400,
+                classesLoaded = 2_500,
+                peakThreads = 12
+            )
+            // pid 20 intentionally omitted → missing snapshot
+        )
+
+        val workers = WorkerReportInput.from(processes, runtimeStats)
+
+        assert(workers.size == 2)
+        val live = workers.single { it.pid == 10L }
+        assert(!live.statsSnapshotMissing)
+        assert(live.task == ":a:test")
+        assert(live.executor == "E1")
+        assert(live.xmx == "512m")
+        assert(live.uptimeMin == 1.0)
+        assert(live.cpuTimeSec == 30.0)
+        assert(live.gcType == "G1")
+
+        val missing = workers.single { it.pid == 20L }
+        assert(missing.statsSnapshotMissing)
+        assert(missing.task == ":b:test")
+        assert(missing.executor == "E2")
+        assert(missing.xmx == "1g")
+        assert(missing.uptimeMin == 0.0)
+        assert(missing.cpuTimeSec == 0.0)
+        assert(missing.cpuCoresAvg == 0.0)
+        assert(missing.heapPeakGb == 0.0)
+        assert(missing.gcType == "Unknown")
+        assert(missing.gcCollections == 0L)
+        assert(missing.classesLoaded == -1L)
+        assert(missing.peakThreads == -1)
+    }
+
+    @Test
     fun reportDocumentFromComputesWorkersSummaryByTaskAndTags() {
         val processes = mapOf(
             10L to TestProcess(task = ":a:test", executor = "E1", max = "512m"),


### PR DESCRIPTION
## Summary

### Problem

`src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt` and `src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt` both translate `Map<Long, TestProcess>` plus `Map<Long, WorkerRuntimeStats>` into `WorkerProcessInfo` with the same `processes.map { (pid, proc) -> ReportJson.workerInfo(proc, runtimeStats[pid], pid) }` expression before applying output-specific formatting.

### Why this matters

The duplicated projection is small today, but it couples both output adapters directly to the collection-state shape. Any future change to worker identity, missing-snapshot handling, ordering, or report input semantics has to be remembered in both adapters, increasing the chance that Build Scan output and local JSON drift.

### Proposed change

Add a tiny report-domain helper, for example `ReportInput` or `WorkerReportInput`, in the `report` package that owns the behavior-preserving conversion from collected state to `List<WorkerProcessInfo>`. Update `BuildScanReport` and `OutputReport` to consume that shared projection, leaving all serialization keys, aggregation behavior, truncation logic, and output paths unchanged.

### Notes

Clean architecture lens: this separates the reporting use-case input model from two infrastructure adapters, making Build Scan and file output depend on the same report-ready worker view instead of each reconstructing it from persistence/collection state.

Fixes #83

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/report/Report.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/report/AggregatorTest.kt`

## Verification

- `./gradlew test`
