### PR TITLE
fix: refactor worker registry mapping to isolate identity translation

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerIdentityMapper.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerIdentityMapper.kt
@@ -1,0 +1,18 @@
+package io.github.cdsap.testprocess.agent
+
+import io.github.cdsap.testprocess.model.TestProcess
+
+internal object WorkerIdentityMapper {
+    fun toTestProcess(entry: WorkerRegistryEntry): TestProcess = TestProcess(
+        task = entry.task,
+        executor = if (entry.executor.isNotEmpty()) entry.executor else "Gradle Test Executor pid-${entry.pid}",
+        max = formatHeap(entry.maxHeapBytes)
+    )
+
+    private fun formatHeap(bytes: Long): String = when {
+        bytes <= 0 -> ""
+        bytes % (1024L * 1024 * 1024) == 0L -> "${bytes / (1024L * 1024 * 1024)}g"
+        bytes >= 1024L * 1024 -> "${bytes / (1024L * 1024)}m"
+        else -> "${bytes}b"
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.testprocess.agent
 
-import io.github.cdsap.testprocess.model.TestProcess
 import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -14,20 +13,7 @@ data class WorkerRegistryEntry(
     val maxHeapBytes: Long = 0,
     val startMs: Long = 0,
     val args: List<String> = emptyList()
-) {
-    fun toTestProcess(): TestProcess = TestProcess(
-        task = task,
-        executor = if (executor.isNotEmpty()) executor else "Gradle Test Executor pid-$pid",
-        max = formatHeap(maxHeapBytes)
-    )
-
-    private fun formatHeap(bytes: Long): String = when {
-        bytes <= 0 -> ""
-        bytes % (1024L * 1024 * 1024) == 0L -> "${bytes / (1024L * 1024 * 1024)}g"
-        bytes >= 1024L * 1024 -> "${bytes / (1024L * 1024)}m"
-        else -> "${bytes}b"
-    }
-}
+)
 
 object WorkerRegistry {
     private val json = Json { ignoreUnknownKeys = true }

--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
@@ -13,7 +13,7 @@ object WorkerStateCollector {
         stats: Stats
     ): PersistedState {
         WorkerRegistry.read(registryDir).forEach { entry ->
-            processes.putIfAbsent(entry.pid, entry.toTestProcess())
+            processes.putIfAbsent(entry.pid, WorkerIdentityMapper.toTestProcess(entry))
         }
         val runtimeStats: Map<Long, WorkerRuntimeStats> =
             WorkerRegistry.readStats(registryDir).associateBy { it.pid }

--- a/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt
@@ -24,8 +24,16 @@ class WorkerRegistryTest {
         assert(entries.size == 2)
         assert(entries[0].pid == 12345L)
         assert(entries[0].task == ":app:test")
-        assert(entries[0].toTestProcess().max == "512m")
-        assert(entries[1].toTestProcess().max == "1g")
+        assert(entries[0].executor == "Gradle Test Executor 1")
+        assert(entries[0].maxHeapBytes == 536870912L)
+        assert(entries[0].startMs == 1700000000000L)
+        assert(entries[0].args == listOf("-Xmx512m", "-Dio.github.cdsap.testprocess.task=:app:test"))
+        assert(entries[1].pid == 67890L)
+        assert(entries[1].task == ":lib:test")
+        assert(entries[1].executor == "Gradle Test Executor 2")
+        assert(entries[1].maxHeapBytes == 1073741824L)
+        assert(entries[1].startMs == 1700000000001L)
+        assert(entries[1].args == listOf("-Xmx1g"))
     }
 
     @Test
@@ -41,13 +49,15 @@ class WorkerRegistryTest {
     }
 
     @Test
-    fun missingExecutorFallsBackToPidLabel() {
+    fun readsMissingExecutorAsEmptyString() {
         val dir = tmp.newFolder("workers")
         File(dir, "7.json").writeText(
             """{"pid":7,"task":":a:test","maxHeapBytes":268435456,"startMs":1,"args":[]}"""
         )
         val entries = WorkerRegistry.read(dir)
-        assert(entries.single().toTestProcess().executor == "Gradle Test Executor pid-7")
+        assert(entries.single().pid == 7L)
+        assert(entries.single().executor == "")
+        assert(entries.single().maxHeapBytes == 268435456L)
     }
 
     @Test

--- a/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
@@ -63,4 +63,23 @@ class WorkerStateCollectorTest {
         assert(stats.statsSnapshotsCaptured == 0)
         assert(stats.statsSnapshotsMissing == 1)
     }
+
+    @Test
+    fun mapsHeapBytesAndMissingExecutorFallback() {
+        val dir = tmp.newFolder("workers")
+        File(dir, "7.json").writeText(
+            """{"pid":7,"task":":a:test","maxHeapBytes":536870912,"startMs":1,"args":[]}"""
+        )
+        File(dir, "8.json").writeText(
+            """{"pid":8,"task":":b:test","executor":"Gradle Test Executor 2","maxHeapBytes":1073741824,"startMs":2,"args":[]}"""
+        )
+
+        val processes = mutableMapOf<Long, TestProcess>()
+        val state = WorkerStateCollector.collect(dir, processes, Stats())
+
+        assert(state.processes[7L]?.executor == "Gradle Test Executor pid-7")
+        assert(state.processes[7L]?.max == "512m")
+        assert(state.processes[8L]?.executor == "Gradle Test Executor 2")
+        assert(state.processes[8L]?.max == "1g")
+    }
 }


### PR DESCRIPTION
## Summary

### Problem

`src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt:9` defines the serialized worker registry DTO, but the same DTO also converts itself into the core `TestProcess` model at `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt:17`. `WorkerStateCollector` then depends on that DTO behavior at `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt:14`, and registry tests assert domain conversion details at `src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt:26` and `src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt:49`.

### Why this matters

The registry reader is an infrastructure concern: it decodes agent JSON files. Having it own fallback executor naming and heap formatting makes that file harder to reason about and pushes domain translation tests into registry parsing tests. Keeping parsing separate from mapping makes future changes to worker identity, heap display, or fallback labels easier to test without touching file IO behavior.

### Proposed change

Move `WorkerRegistryEntry.toTestProcess()` and its heap-formatting helper out of `WorkerRegistry.kt` into a small mapper used by `WorkerStateCollector`, for example an internal `WorkerIdentityMapper` in `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt` or a new focused file in the same package. Keep `WorkerRegistry.read` responsible only for tolerant JSON file discovery and decoding. Shift conversion assertions from `WorkerRegistryTest` into `WorkerStateCollectorTest` or a dedicated mapper test.

### Notes

Clean architecture lens: keep the file-system adapter focused on deserialization and move translation into the application collection step. This is a small boundary clarification, not a redesign.

Fixes #86

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerIdentityMapper.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistry.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerRegistryTest.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt`

## Verification

- `./gradlew test`
