### PR TITLE
fix: declare plugin portal configuration-cache compatibility (and prove

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
+import org.gradle.plugin.compatibility.compatibility
+
 plugins {
     `java-gradle-plugin`
     `maven-publish`
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "1.0.0-rc-1"
+    id("com.gradle.plugin-publish") version "2.1.1"
     kotlin("plugin.serialization") version "2.4.10"
 
 }
@@ -52,20 +54,23 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 gradlePlugin {
+    website.set("https://github.com/cdsap/InfoTestProcess")
+    vcsUrl.set("https://github.com/cdsap/InfoTestProcess")
     plugins {
         create("InfoTestProcessPlugin") {
             id = "io.github.cdsap.testprocess"
             displayName = "Info Test Processes"
             description = "Retrieve information of the Test processes after the build execution"
             implementationClass = "io.github.cdsap.testprocess.InfoTestProcessPlugin"
+            tags.set(listOf("test", "process"))
+            // Proven by IntegrationNoDvTest / e2e-cc (store then HIT with --configuration-cache).
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
-}
-
-pluginBundle {
-    website = "https://github.com/cdsap/InfoTestProcess"
-    vcsUrl = "https://github.com/cdsap/InfoTestProcess"
-    tags = listOf("test", "process")
 }
 
 publishing {

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
@@ -1,9 +1,7 @@
 package io.github.cdsap.testprocess
 
 import junit.framework.TestCase.assertTrue
-import org.gradle.kotlin.dsl.accessors.runtime.addDependencyTo
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -15,22 +13,24 @@ class IntegrationNoDvTest {
     val testProjectDir = TemporaryFolder()
 
     @Test
-    fun testPluginIsCompatibleWithConfigurationCacheWithGradleEnterprise() {
-
+    fun testPluginIsCompatibleWithConfigurationCache() {
+        // Proves Portal compatibility.features.configurationCache = true:
+        // representative task twice with CC enabled, second run must be a HIT,
+        // and --configuration-cache-problems=fail ensures no CC problems.
         createProject()
 
+        val ccArgs = listOf("test", "--configuration-cache", "--configuration-cache-problems=fail")
         listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("test", "--configuration-cache")
+                .withArguments(ccArgs)
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
 
-
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("test", "--configuration-cache")
+                .withArguments(ccArgs)
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationTest.kt
@@ -2,7 +2,6 @@ package io.github.cdsap.testprocess
 
 import junit.framework.TestCase.assertTrue
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -14,11 +13,6 @@ class InfoTestProcessPluginTest {
 
     @Test
     fun testPluginIsCompatibleWithConfigurationCacheWithGradleEnterprise() {
-//        assumeTrue(
-//            "Gradle Enterprise URL and Access Key are set",
-//            System.getenv("GE_URL") != null && System.getenv("GE_API_KEY") != null
-//        )
-
         testProjectDir.newFile("settings.gradle").appendText(
             """
                 plugins {
@@ -52,16 +46,17 @@ class InfoTestProcessPluginTest {
                 }
             """.trimIndent()
         )
+        val ccArgs = listOf("test", "--configuration-cache", "--configuration-cache-problems=fail")
         listOf("8.14.3", "9.1.0", "9.7.1").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("test", "--configuration-cache")
+                .withArguments(ccArgs)
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("test", "--configuration-cache")
+                .withArguments(ccArgs)
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()


### PR DESCRIPTION
## Summary

### Notes

Related Gradle docs: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:plugins

Fixes #89

## Changes

- `build.gradle.kts`
- `src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/IntegrationTest.kt`

## Verification

- `./gradlew test`
