### PR TITLE
fix: gbos: add opt-in develocity projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ the heaviest workers by `cpuTimeSec` are kept and the plugin emits
 `testProcess.worker.truncated=true` plus `testProcess.worker.total=<count>` so you
 know data was dropped.
 
+#### Optional GBOS projection
+
+Set `infoTestProcess.gbos.develocity.enabled=true` in `gradle.properties` to also
+publish the opt-in GBOS Develocity projection during same-major adoption. Legacy
+`testProcess.*` custom values and scan tags remain unchanged.
+
+The projection emits canonical observations as repeated `gbos.v1.observation`
+custom values. Any PID, task path, or test executor identity is stored inside the
+observation JSON attributes, not in custom-value names. It also emits only the
+allowlisted build-level scalar indexes:
+
+| Key | Source measurement |
+|---|---|
+| `gbos.v1.index.info_test_process.jvm.process.cpu.cores.max` | `jvm.process.cpu.cores` / `max` |
+| `gbos.v1.index.info_test_process.jvm.process.cpu.time.sum` | `jvm.process.cpu.time` / `sum` |
+| `gbos.v1.index.info_test_process.jvm.process.memory.heap.peak.max` | `jvm.process.memory.heap.peak` / `max` |
+
 #### Scan tags
 
 Categorical filters for fast slicing in DRV. Fired automatically when thresholds hit:

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -57,7 +57,12 @@ class InfoTestProcessPlugin : Plugin<Settings> {
                 parameters.file.set(persistedTxt)
             }
             if (develocityConfiguration != null) {
-                BuildScanReport().develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
+                val publishGbosToDevelocity = providers.gradleProperty("infoTestProcess.gbos.develocity.enabled")
+                    .map { it.toBoolean() }
+                    .orElse(false)
+                    .get()
+                BuildScanReport(publishGbosToDevelocity)
+                    .develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
             }
 
             wireProject = { project ->

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt
@@ -7,7 +7,9 @@ import io.github.cdsap.testprocess.model.TestProcess
 import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import org.gradle.api.provider.Provider
 
-class BuildScanReport : Report {
+class BuildScanReport(
+    private val publishGbos: Boolean = false
+) : Report {
 
     fun develocityBuildScanReporting(
         develocityConfiguration: DevelocityConfiguration,
@@ -75,5 +77,9 @@ class BuildScanReport : Report {
 
         // Scan tags for fast categorical filtering in DRV.
         tags.forEach { buildScanData.tag(it) }
+
+        if (publishGbos) {
+            GbosDevelocityProjection.publish(report, buildScanData)
+        }
     }
 }

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/GbosDevelocityProjection.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/GbosDevelocityProjection.kt
@@ -1,0 +1,218 @@
+package io.github.cdsap.testprocess.report
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.math.BigDecimal
+
+internal object GbosDevelocityProjection {
+    private const val OBSERVATION_CUSTOM_VALUE = "gbos.v1.observation"
+    private const val SCHEMA_VERSION = "1.0.0"
+    private const val PRODUCER_NAME = "info-test-process"
+    private const val PRODUCER_VERSION = "2.1.0"
+    private const val PROCESS_SCOPE = "jvm.process"
+    private const val ROLE_ATTRIBUTE = "jvm.process.role"
+    private const val TEST_WORKER_ROLE = "test-worker"
+
+    private val ALLOWLISTED_INDEXES = listOf(
+        Triple(
+            "gbos.v1.index.info_test_process.jvm.process.cpu.cores.max",
+            "jvm.process.cpu.cores",
+            "max"
+        ),
+        Triple(
+            "gbos.v1.index.info_test_process.jvm.process.cpu.time.sum",
+            "jvm.process.cpu.time",
+            "sum"
+        ),
+        Triple(
+            "gbos.v1.index.info_test_process.jvm.process.memory.heap.peak.max",
+            "jvm.process.memory.heap.peak",
+            "max"
+        )
+    )
+
+    fun publish(report: ReportDocument, buildScanData: BuildScanData) {
+        val workersByImportance = report.workers.sortedByDescending { it.cpuTimeSec }
+        val emittedWorkers = workersByImportance.take(WORKERS_PER_PID_CAP)
+        val droppedObservations = workersByImportance.size - emittedWorkers.size
+
+        emittedWorkers
+            .mapNotNull { workerObservation(it) }
+            .forEach { observation ->
+                buildScanData.value(OBSERVATION_CUSTOM_VALUE, encode(observation))
+            }
+
+        val hasLiveWorkers = report.workers.any { !it.statsSnapshotMissing }
+        val buildObservation = buildObservation(report.summary, hasLiveWorkers, droppedObservations) ?: return
+        buildScanData.value(OBSERVATION_CUSTOM_VALUE, encode(buildObservation))
+        scalarIndexes(buildObservation).forEach { (name, value) ->
+            buildScanData.value(name, formatNumber(value))
+        }
+    }
+
+    private fun workerObservation(worker: WorkerProcessInfo): JsonObject? {
+        val measurements = buildJsonArray {
+            measurement("jvm.process.memory.heap.limit", xmxBytes(worker.xmx), "By", "last")?.let { add(it) }
+            if (!worker.statsSnapshotMissing) {
+                measurement("jvm.process.uptime", worker.uptimeMin * 60.0, "s", "last")?.let { add(it) }
+                measurement("jvm.process.cpu.time", worker.cpuTimeSec, "s", "sum")?.let { add(it) }
+                measurement("jvm.process.cpu.cores", worker.cpuCoresAvg, "{core}", "last")?.let { add(it) }
+                measurement("jvm.process.memory.heap.used", gibToBytes(worker.heapUsageGb), "By", "last")?.let { add(it) }
+                measurement("jvm.process.memory.heap.peak", gibToBytes(worker.heapPeakGb), "By", "max")?.let { add(it) }
+                measurement("jvm.process.memory.metaspace.peak", mibToBytes(worker.metaspacePeakMb), "By", "max")?.let { add(it) }
+                measurement("jvm.process.gc.collections", worker.gcCollections.toDouble(), "{collection}", "count")?.let { add(it) }
+                measurement("jvm.process.gc.time", worker.gcTimeSec, "s", "sum")?.let { add(it) }
+                measurement("jvm.process.jit.time", worker.jitSec, "s", "sum")?.let { add(it) }
+                measurement("jvm.process.classes.loaded", worker.classesLoaded.toDouble(), "{class}", "last")?.let { add(it) }
+                measurement("jvm.process.threads.peak", worker.peakThreads.toDouble(), "{thread}", "max")?.let { add(it) }
+            }
+        }
+        if (measurements.isEmpty()) return null
+
+        val diagnostics = if (worker.statsSnapshotMissing) {
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("code", "gbos.test_process.stats_snapshot_missing")
+                        put("severity", "warning")
+                    }
+                )
+            }
+        } else {
+            null
+        }
+        return observation("entity", workerAttributes(worker), measurements, diagnostics)
+    }
+
+    private fun buildObservation(
+        summary: TestProcessSummary,
+        hasLiveWorkers: Boolean,
+        droppedObservations: Int
+    ): JsonObject? {
+        val measurements = buildJsonArray {
+            if (hasLiveWorkers) {
+                measurement("jvm.process.cpu.cores", summary.cpuCoresAvgMax, "{core}", "max")?.let { add(it) }
+                measurement("jvm.process.cpu.time", summary.cpuTimeSecSum, "s", "sum")?.let { add(it) }
+                measurement("jvm.process.memory.heap.peak", gibToBytes(summary.heapPeakGbMax), "By", "max")?.let { add(it) }
+                measurement("jvm.process.memory.metaspace.peak", mibToBytes(summary.metaspacePeakMbMax), "By", "max")?.let { add(it) }
+                measurement("jvm.process.jit.time", summary.jitSecSum, "s", "sum")?.let { add(it) }
+                measurement("jvm.process.jit.time", summary.jitSecMax, "s", "max")?.let { add(it) }
+                measurement("jvm.process.classes.loaded", summary.classesLoadedMax.toDouble(), "{class}", "max")?.let { add(it) }
+                measurement("jvm.process.gc.collections", summary.gcCollectionsSum.toDouble(), "{collection}", "sum")?.let { add(it) }
+                measurement("jvm.process.uptime", summary.uptimeMinSum * 60.0, "s", "sum")?.let { add(it) }
+            }
+        }
+        if (measurements.isEmpty()) return null
+
+        val diagnostics = if (droppedObservations > 0) {
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("code", "gbos.limit.observations_dropped")
+                        put("severity", "warning")
+                    }
+                )
+            }
+        } else {
+            null
+        }
+        return observation(
+            aggregationScope = "build",
+            attributes = buildJsonObject { put(ROLE_ATTRIBUTE, TEST_WORKER_ROLE) },
+            measurements = measurements,
+            diagnostics = diagnostics,
+            partial = droppedObservations > 0,
+            droppedObservations = droppedObservations.takeIf { it > 0 }
+        )
+    }
+
+    private fun workerAttributes(worker: WorkerProcessInfo): JsonObject = buildJsonObject {
+        put("process.pid", worker.pid)
+        put(ROLE_ATTRIBUTE, TEST_WORKER_ROLE)
+        put("gradle.task.path", worker.task)
+        put("gradle.test.executor", worker.executor)
+        if (!worker.statsSnapshotMissing && worker.gcType != "Unknown") {
+            put("jvm.gc.name", worker.gcType)
+        }
+    }
+
+    private fun observation(
+        aggregationScope: String,
+        attributes: JsonObject,
+        measurements: JsonArray,
+        diagnostics: JsonArray? = null,
+        partial: Boolean = false,
+        droppedObservations: Int? = null
+    ): JsonObject = buildJsonObject {
+        put("schemaVersion", SCHEMA_VERSION)
+        put(
+            "producer",
+            buildJsonObject {
+                put("name", PRODUCER_NAME)
+                put("version", PRODUCER_VERSION)
+            }
+        )
+        put("scope", PROCESS_SCOPE)
+        put("aggregationScope", aggregationScope)
+        put("attributes", attributes)
+        if (measurements.isNotEmpty()) {
+            put("measurements", measurements)
+        }
+        if (partial) {
+            put("partial", true)
+        }
+        if (droppedObservations != null) {
+            put("droppedObservations", droppedObservations)
+        }
+        if (diagnostics != null) {
+            put("diagnostics", diagnostics)
+        }
+    }
+
+    private fun scalarIndexes(buildObservation: JsonObject): List<Pair<String, Double>> {
+        val measurements = buildObservation["measurements"] as? JsonArray ?: return emptyList()
+        return ALLOWLISTED_INDEXES.mapNotNull { (indexName, metric, aggregation) ->
+            val value = measurements
+                .map { it as JsonObject }
+                .singleOrNull {
+                    it["name"] == JsonPrimitive(metric) &&
+                        it["aggregation"] == JsonPrimitive(aggregation)
+                }
+                ?.get("value")
+                ?.jsonPrimitive
+                ?.double
+            value?.let { indexName to it }
+        }
+    }
+
+    private fun measurement(name: String, value: Double?, unit: String, aggregation: String): JsonObject? {
+        if (value == null) return null
+        return buildJsonObject {
+            put("name", name)
+            put("value", jsonNumber(value))
+            put("unit", unit)
+            put("aggregation", aggregation)
+        }
+    }
+
+    private fun xmxBytes(xmx: String): Double? = Aggregator.parseXmxGb(xmx)?.let(::gibToBytes)
+
+    private fun gibToBytes(value: Double): Double = Math.round(value * 1024.0 * 1024.0 * 1024.0).toDouble()
+
+    private fun mibToBytes(value: Double): Double = Math.round(value * 1024.0 * 1024.0).toDouble()
+
+    private fun formatNumber(value: Double): String = jsonNumber(value).content
+
+    private fun jsonNumber(value: Double): JsonPrimitive =
+        JsonUnquotedLiteral(BigDecimal.valueOf(value).stripTrailingZeros().toPlainString())
+
+    private fun encode(observation: JsonObject): String =
+        ReportJson.json.encodeToString(JsonObject.serializer(), observation)
+}

--- a/src/test/kotlin/io/github/cdsap/testprocess/report/BuildScanReportTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/report/BuildScanReportTest.kt
@@ -1,0 +1,174 @@
+package io.github.cdsap.testprocess.report
+
+import io.github.cdsap.testprocess.model.Stats
+import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+class BuildScanReportTest {
+    private val processes = mapOf(
+        13402L to TestProcess(task = ":core:test", executor = "Gradle Test Executor 5", max = "512m")
+    )
+    private val runtimeStats = mapOf(
+        13402L to WorkerRuntimeStats(
+            pid = 13402L,
+            uptimeMs = 120_000,
+            cpuTimeMs = 3_050,
+            usedHeapBytes = 100_000_000,
+            peakHeapBytes = 150_323_855,
+            peakMetaspaceBytes = 50_331_648,
+            maxHeapBytes = 536_870_912,
+            gcCollections = 2,
+            gcTimeMs = 50,
+            gcType = "G1",
+            jitTimeMs = 1_250,
+            classesLoaded = 3_503,
+            peakThreads = 10
+        )
+    )
+
+    @Test
+    fun gbosDevelocityProjectionIsDisabledByDefault() {
+        val scanData = RecordingBuildScanData()
+
+        BuildScanReport().extracted(processes, runtimeStats, Stats(), scanData)
+
+        assert(scanData.values.any { it.first == "testProcess.cpuTimeSec.sum" })
+        assert(scanData.values.none { it.first == "gbos.v1.observation" })
+        assert(scanData.values.none { it.first.startsWith("gbos.v1.index.") })
+    }
+
+    @Test
+    fun emitsCanonicalGbosObservationValuesWhenEnabled() {
+        val scanData = RecordingBuildScanData()
+
+        BuildScanReport(publishGbos = true).extracted(processes, runtimeStats, Stats(), scanData)
+
+        val observations = scanData.values
+            .filter { it.first == "gbos.v1.observation" }
+            .map { it.second.asJsonObject() }
+
+        assert(observations.size == 2)
+        assert(scanData.values.filter { it.first.startsWith("gbos.v1.") }.all { (name, _) ->
+            "13402" !in name &&
+                ":core:test" !in name &&
+                "Gradle Test Executor 5" !in name
+        })
+        assert(observations.all { it["schemaVersion"]!!.jsonPrimitive.content == "1.0.0" })
+        assert(observations.all { it["producer"]!!.jsonObject["name"]!!.jsonPrimitive.content == "info-test-process" })
+        assert(observations.all { it["producer"]!!.jsonObject["version"]!!.jsonPrimitive.content == "2.1.0" })
+        assert(observations.all { it["scope"]!!.jsonPrimitive.content == "jvm.process" })
+
+        val entity = observations.single { it["aggregationScope"]!!.jsonPrimitive.content == "entity" }
+        val entityAttributes = entity["attributes"]!!.jsonObject
+        assert(entityAttributes["process.pid"]!!.jsonPrimitive.content == "13402")
+        assert(entityAttributes["jvm.process.role"]!!.jsonPrimitive.content == "test-worker")
+        assert(entityAttributes["gradle.task.path"]!!.jsonPrimitive.content == ":core:test")
+        assert(entityAttributes["gradle.test.executor"]!!.jsonPrimitive.content == "Gradle Test Executor 5")
+        assert(entityAttributes["jvm.gc.name"]!!.jsonPrimitive.content == "G1")
+        assert(entity.measurement("jvm.process.memory.heap.limit", "last") == 536_870_912.0)
+        assert(entity.measurement("jvm.process.cpu.time", "sum") == 3.05)
+        assert(entity.measurement("jvm.process.memory.heap.peak", "max") == 150_323_855.0)
+
+        val build = observations.single { it["aggregationScope"]!!.jsonPrimitive.content == "build" }
+        assert(build["attributes"]!!.jsonObject.keys == setOf("jvm.process.role"))
+        assert(build.measurement("jvm.process.cpu.cores", "max") == 0.03)
+        assert(build.measurement("jvm.process.cpu.time", "sum") == 3.05)
+        assert(build.measurement("jvm.process.memory.heap.peak", "max") == 150_323_855.0)
+    }
+
+    @Test
+    fun emitsOnlyAllowlistedScalarIndexesFromBuildLevelMeasurements() {
+        val scanData = RecordingBuildScanData()
+
+        BuildScanReport(publishGbos = true).extracted(processes, runtimeStats, Stats(), scanData)
+
+        val indexes = scanData.values
+            .filter { it.first.startsWith("gbos.v1.index.") }
+            .toMap()
+
+        assert(
+            indexes.keys == setOf(
+                "gbos.v1.index.info_test_process.jvm.process.cpu.cores.max",
+                "gbos.v1.index.info_test_process.jvm.process.cpu.time.sum",
+                "gbos.v1.index.info_test_process.jvm.process.memory.heap.peak.max"
+            )
+        )
+
+        val build = scanData.values
+            .filter { it.first == "gbos.v1.observation" }
+            .map { it.second.asJsonObject() }
+            .single { it["aggregationScope"]!!.jsonPrimitive.content == "build" }
+
+        assert(indexes["gbos.v1.index.info_test_process.jvm.process.cpu.cores.max"]!!.toDouble() == build.measurement("jvm.process.cpu.cores", "max"))
+        assert(indexes["gbos.v1.index.info_test_process.jvm.process.cpu.time.sum"]!!.toDouble() == build.measurement("jvm.process.cpu.time", "sum"))
+        assert(indexes["gbos.v1.index.info_test_process.jvm.process.memory.heap.peak.max"]!!.toDouble() == build.measurement("jvm.process.memory.heap.peak", "max"))
+    }
+
+    @Test
+    fun keepsLegacyDevelocityCustomValuesAndTagsWhenGbosIsEnabled() {
+        val heavyStats = mapOf(
+            13402L to runtimeStats.getValue(13402L).copy(
+                cpuTimeMs = 500_000,
+                uptimeMs = 100_000
+            )
+        )
+        val scanData = RecordingBuildScanData()
+
+        BuildScanReport(publishGbos = true).extracted(processes, heavyStats, Stats(), scanData)
+
+        assert(scanData.values.any { it.first == "testProcess.cpuTimeSec.sum" })
+        assert(scanData.values.any { it.first == "testProcess.worker.13402" })
+        assert(scanData.tags == listOf("tests:cpu-heavy"))
+        assert(scanData.values.any { it.first == "gbos.v1.observation" })
+    }
+
+    @Test
+    fun omitsMissingSnapshotSentinelsFromGbosObservations() {
+        val scanData = RecordingBuildScanData()
+
+        BuildScanReport(publishGbos = true).extracted(processes, emptyMap(), Stats(statsSnapshotsMissing = 1), scanData)
+
+        val observations = scanData.values
+            .filter { it.first == "gbos.v1.observation" }
+            .map { it.second.asJsonObject() }
+        val entity = observations.single { it["aggregationScope"]!!.jsonPrimitive.content == "entity" }
+        val measurementNames = entity["measurements"]!!.jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+        assert(measurementNames == listOf("jvm.process.memory.heap.limit"))
+        assert(entity.measurement("jvm.process.memory.heap.limit", "last") == 536_870_912.0)
+        assert(entity["diagnostics"]!!.jsonArray.single().jsonObject["code"]!!.jsonPrimitive.content == "gbos.test_process.stats_snapshot_missing")
+        assert(observations.none { it["aggregationScope"]!!.jsonPrimitive.content == "build" })
+        assert(scanData.values.none { it.first.startsWith("gbos.v1.index.") })
+        assert("-1" !in entity.toString())
+    }
+
+    private fun String.asJsonObject(): JsonObject = ReportJson.json.parseToJsonElement(this).jsonObject
+
+    private fun JsonObject.measurement(name: String, aggregation: String): Double {
+        return this["measurements"]!!.jsonArray
+            .map { it.jsonObject }
+            .single {
+                it["name"]!!.jsonPrimitive.content == name &&
+                    it["aggregation"]!!.jsonPrimitive.content == aggregation
+            }["value"]!!.jsonPrimitive.double
+    }
+
+    private class RecordingBuildScanData : BuildScanData {
+        val values = mutableListOf<Pair<String, String>>()
+        val tags = mutableListOf<String>()
+
+        override fun value(key: String, value: String) {
+            values += key to value
+        }
+
+        override fun tag(name: String) {
+            tags += name
+        }
+    }
+}


### PR DESCRIPTION
## Summary

## Goal

Add opt-in Develocity GBOS projection.

## Requirements

Fixes #97

## Changes

- `README.md`
- `src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/report/BuildScanReport.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/report/GbosDevelocityProjection.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/report/BuildScanReportTest.kt`

## Verification

- `./gradlew test`
