### PR TITLE
fix: gbos: add default-off opt-in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ legacy output in two modes:
 | Develocity applied | Custom values + scan tags published to the Build Scan |
 | No Develocity | Structured JSON file at `${rootDir}/build/info-test-process/statsTestTasks.json` |
 
-GBOS output is experimental and disabled by default. Enabling it is opt-in and
-does not change legacy JSON, Build Scan custom values, or tags. File sinks and
-Develocity GBOS publishing can be enabled independently during same-major
-adoption.
+GBOS output is experimental and disabled by default (`gbos.enabled=false`).
+Enabling it is opt-in and does not change legacy JSON, Build Scan custom values,
+or tags. File sinks and Develocity GBOS publishing can be enabled independently
+during same-major adoption. Prefer Gradle properties for CI-friendly opt-in.
 
 ## Output
 
@@ -95,9 +95,10 @@ know data was dropped.
 
 #### Optional GBOS projection
 
-Set `infoTestProcess.gbos.develocity.enabled=true` in `gradle.properties` to also
-publish the opt-in GBOS Develocity projection during same-major adoption. Legacy
-`testProcess.*` custom values and scan tags remain unchanged.
+Set `infoTestProcess.gbos.develocity.enabled=true` in `gradle.properties` to
+publish the opt-in GBOS Develocity projection. This flag is independent of file
+output and of `infoTestProcess.gbos.enabled`. Legacy `testProcess.*` custom
+values and scan tags remain unchanged.
 
 The projection emits canonical observations as repeated `gbos.v1.observation`
 custom values. Any PID, task path, or test executor identity is stored inside the
@@ -112,15 +113,33 @@ allowlisted build-level scalar indexes:
 
 ### Optional GBOS file output
 
-Set either or both properties in `gradle.properties` (both default to `false`):
+GBOS file output is off unless you opt in. The simplest CI-friendly switch:
+
+```properties
+infoTestProcess.gbos.enabled=true
+```
+
+That enables both JSON and NDJSON sinks. You can also target a single sink
+(these override the master flag when set):
 
 ```properties
 infoTestProcess.gbos.json.enabled=true
 infoTestProcess.gbos.ndjson.enabled=true
 ```
 
-When disabled, no GBOS files are written. The JSON sink writes a GBOS report
-envelope to `${rootDir}/build/info-test-process/gbos.json`:
+The same options are available on the Settings extension:
+
+```kotlin
+infoTestProcess {
+    gbos {
+        enabled.set(true)
+        // develocity.set(true) // independent of file sinks
+    }
+}
+```
+
+When disabled, no GBOS files are written and legacy output is unchanged. The JSON
+sink writes a GBOS report envelope to `${rootDir}/build/info-test-process/gbos.json`:
 
 ```json
 {

--- a/src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt
@@ -1,0 +1,33 @@
+package io.github.cdsap.testprocess
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+/**
+ * Settings-level configuration for InfoTestProcess.
+ *
+ * Prefer Gradle properties for CI opt-in; the DSL mirrors the same flags.
+ */
+abstract class InfoTestProcessExtension @Inject constructor(objects: ObjectFactory) {
+    val gbos: GbosExtension = objects.newInstance(GbosExtension::class.java)
+
+    fun gbos(action: Action<in GbosExtension>) {
+        action.execute(gbos)
+    }
+}
+
+/**
+ * Opt-in GBOS configuration. All flags default to disabled.
+ *
+ * - [enabled] turns on both file sinks (JSON + NDJSON) unless overridden.
+ * - [json] / [ndjson] refine file output independently of each other.
+ * - [develocity] is independent of file output.
+ */
+abstract class GbosExtension {
+    abstract val enabled: Property<Boolean>
+    abstract val json: Property<Boolean>
+    abstract val ndjson: Property<Boolean>
+    abstract val develocity: Property<Boolean>
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/GbosOptIn.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/GbosOptIn.kt
@@ -1,0 +1,48 @@
+package io.github.cdsap.testprocess
+
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+
+/**
+ * Gradle property names and resolution rules for experimental GBOS opt-in.
+ *
+ * File sinks follow [PROPERTY_ENABLED] unless a sink-specific property is set.
+ * Develocity publishing is always separate from file output.
+ */
+internal object GbosOptIn {
+    const val PROPERTY_ENABLED = "infoTestProcess.gbos.enabled"
+    const val PROPERTY_JSON = "infoTestProcess.gbos.json.enabled"
+    const val PROPERTY_NDJSON = "infoTestProcess.gbos.ndjson.enabled"
+    const val PROPERTY_DEVELOCITY = "infoTestProcess.gbos.develocity.enabled"
+
+    fun writeJson(enabled: Boolean, json: Boolean?): Boolean = json ?: enabled
+
+    fun writeNdjson(enabled: Boolean, ndjson: Boolean?): Boolean = ndjson ?: enabled
+
+    fun publishDevelocity(develocity: Boolean): Boolean = develocity
+
+    fun configureConventions(extension: GbosExtension, providers: ProviderFactory) {
+        extension.enabled.convention(booleanProperty(providers, PROPERTY_ENABLED, default = false))
+        // Absent sink-specific properties fall back to [enabled], so a single
+        // infoTestProcess.gbos.enabled=true opts into both file sinks.
+        extension.json.convention(
+            optionalBooleanProperty(providers, PROPERTY_JSON).orElse(extension.enabled)
+        )
+        extension.ndjson.convention(
+            optionalBooleanProperty(providers, PROPERTY_NDJSON).orElse(extension.enabled)
+        )
+        extension.develocity.convention(
+            booleanProperty(providers, PROPERTY_DEVELOCITY, default = false)
+        )
+    }
+
+    private fun booleanProperty(
+        providers: ProviderFactory,
+        name: String,
+        default: Boolean
+    ): Provider<Boolean> =
+        optionalBooleanProperty(providers, name).orElse(default)
+
+    private fun optionalBooleanProperty(providers: ProviderFactory, name: String): Provider<Boolean> =
+        providers.gradleProperty(name).map { it.toBoolean() }
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -20,6 +20,11 @@ import org.gradle.process.CommandLineArgumentProvider
 class InfoTestProcessPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
         val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
+        val gbos = target.extensions.create(
+            "infoTestProcess",
+            InfoTestProcessExtension::class.java
+        ).gbos
+        GbosOptIn.configureConventions(gbos, target.providers)
 
         // Populated by the rootProject {} action below, which runs when the root project is
         // instantiated — before any project (including the root) is configured, so the
@@ -55,23 +60,15 @@ class InfoTestProcessPlugin : Plugin<Settings> {
                 parameters.registryDir = registryDir.map { it.asFile }
                 parameters.agentJar = agentJar.map { it.asFile }
                 parameters.develocity = providers.provider { develocityConfiguration != null }
-                parameters.gbosJsonOutput = providers.gradleProperty("infoTestProcess.gbos.json.enabled")
-                    .map { it.toBoolean() }
-                    .orElse(false)
-                parameters.gbosNdjsonOutput = providers.gradleProperty("infoTestProcess.gbos.ndjson.enabled")
-                    .map { it.toBoolean() }
-                    .orElse(false)
+                parameters.gbosJsonOutput = gbos.json
+                parameters.gbosNdjsonOutput = gbos.ndjson
             }
 
             val persistedStateProvider = providers.of(PersistedDeserializationValueSource::class) {
                 parameters.file.set(persistedTxt)
             }
             if (develocityConfiguration != null) {
-                val publishGbosToDevelocity = providers.gradleProperty("infoTestProcess.gbos.develocity.enabled")
-                    .map { it.toBoolean() }
-                    .orElse(false)
-                    .get()
-                BuildScanReport(publishGbosToDevelocity)
+                BuildScanReport(gbos.develocity.get())
                     .develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
             }
 

--- a/src/test/kotlin/io/github/cdsap/testprocess/GbosOptInTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/GbosOptInTest.kt
@@ -1,0 +1,41 @@
+package io.github.cdsap.testprocess
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GbosOptInTest {
+    @Test
+    fun defaultsDisableAllGbosOutputs() {
+        assertFalse(GbosOptIn.writeJson(enabled = false, json = null))
+        assertFalse(GbosOptIn.writeNdjson(enabled = false, ndjson = null))
+        assertFalse(GbosOptIn.publishDevelocity(develocity = false))
+    }
+
+    @Test
+    fun masterEnabledOptsIntoBothFileSinks() {
+        assertTrue(GbosOptIn.writeJson(enabled = true, json = null))
+        assertTrue(GbosOptIn.writeNdjson(enabled = true, ndjson = null))
+    }
+
+    @Test
+    fun masterEnabledDoesNotImplyDevelocityPublishing() {
+        assertFalse(GbosOptIn.publishDevelocity(develocity = false))
+        assertTrue(GbosOptIn.publishDevelocity(develocity = true))
+    }
+
+    @Test
+    fun sinkSpecificFlagsOverrideMasterEnabled() {
+        assertFalse(GbosOptIn.writeJson(enabled = true, json = false))
+        assertTrue(GbosOptIn.writeJson(enabled = false, json = true))
+        assertFalse(GbosOptIn.writeNdjson(enabled = true, ndjson = false))
+        assertTrue(GbosOptIn.writeNdjson(enabled = false, ndjson = true))
+    }
+
+    @Test
+    fun develocityIsIndependentOfFileOptIn() {
+        assertTrue(GbosOptIn.publishDevelocity(develocity = true))
+        assertFalse(GbosOptIn.writeJson(enabled = false, json = null))
+        assertFalse(GbosOptIn.writeNdjson(enabled = false, ndjson = null))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt
@@ -114,12 +114,59 @@ class IntegrationNoDvTest {
         assertTrue(lines.all { it.startsWith("{") && it.endsWith("}") })
     }
 
-    private fun createProject(extraGradleProperties: String = "") {
+    @Test
+    fun gbosMasterEnabledPropertyOptsIntoBothFileSinks() {
+        createProject(
+            extraGradleProperties = "infoTestProcess.gbos.enabled=true"
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("test", "--configuration-cache")
+            .withPluginClasspath()
+            .withGradleVersion("9.7.1")
+            .build()
+
+        val gbosJson = File("${testProjectDir.root}/build/info-test-process/gbos.json")
+        val gbosNdjson = File("${testProjectDir.root}/build/info-test-process/gbos.ndjson")
+        assertTrue(gbosJson.exists())
+        assertTrue(gbosNdjson.exists())
+        assertTrue(gbosJson.readText().contains("\"observations\""))
+    }
+
+    @Test
+    fun gbosExtensionDslCanEnableFileOutput() {
+        createProject(
+            settingsExtra = """
+                    infoTestProcess {
+                        gbos {
+                            enabled = true
+                        }
+                    }
+            """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("test", "--configuration-cache")
+            .withPluginClasspath()
+            .withGradleVersion("9.7.1")
+            .build()
+
+        assertTrue(File("${testProjectDir.root}/build/info-test-process/gbos.json").exists())
+        assertTrue(File("${testProjectDir.root}/build/info-test-process/gbos.ndjson").exists())
+    }
+
+    private fun createProject(
+        extraGradleProperties: String = "",
+        settingsExtra: String = ""
+    ) {
         testProjectDir.newFile("settings.gradle").appendText(
             """
                     plugins {
                        id 'io.github.cdsap.testprocess'
                     }
+                    $settingsExtra
 
                 """.trimIndent()
         )


### PR DESCRIPTION
## Summary

## Goal

Add opt-in configuration for GBOS support while preserving current same-major defaults.

## Requirements

Fixes #96

## Changes

- `README.md`
- `src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/GbosOptIn.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/GbosOptInTest.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/IntegrationNoDvTest.kt`

## Verification

- `./gradlew test`
