### PR TITLE
fix: refactor outputreport to drop unused buildscandata port

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/report/JsonValue.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/JsonValue.kt
@@ -1,6 +1,0 @@
-package io.github.cdsap.testprocess.report
-
-class JsonValue : BuildScanData {
-    override fun value(key: String, value: String) {}
-    override fun tag(name: String) {}
-}

--- a/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt
@@ -14,13 +14,12 @@ data class OutputDocument(
     val tags: List<String>
 )
 
-class OutputReport(val outputJson: File) : Report {
+class OutputReport(val outputJson: File) {
 
-    override fun extracted(
+    fun write(
         processes: Map<Long, TestProcess>,
         runtimeStats: Map<Long, WorkerRuntimeStats>,
-        stats: Stats,
-        buildScanData: BuildScanData
+        stats: Stats
     ) {
         if (processes.isEmpty()) {
             outputJson.writeText("{}")

--- a/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
@@ -6,7 +6,6 @@ import io.github.cdsap.testprocess.model.PersistedState
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
 import io.github.cdsap.testprocess.report.GbosOutputReport
-import io.github.cdsap.testprocess.report.JsonValue
 import io.github.cdsap.testprocess.report.OutputReport
 import io.github.cdsap.testprocess.report.ReportDocument
 import kotlinx.serialization.json.Json
@@ -56,11 +55,10 @@ abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, A
         } else {
             val outputJson = parameters.pathJson.get()
             outputJson.parentFile?.mkdirs()
-            OutputReport(outputJson).extracted(
+            OutputReport(outputJson).write(
                 payload.processes,
                 payload.runtimeStats,
-                payload.stats,
-                JsonValue()
+                payload.stats
             )
         }
         val writeGbosJson = parameters.gbosJsonOutput.get()

--- a/src/test/kotlin/io/github/cdsap/testprocess/report/OutputReportTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/report/OutputReportTest.kt
@@ -1,0 +1,63 @@
+package io.github.cdsap.testprocess.report
+
+import io.github.cdsap.testprocess.model.Stats
+import io.github.cdsap.testprocess.model.TestProcess
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class OutputReportTest {
+
+    @Rule
+    @JvmField
+    val temp = TemporaryFolder()
+
+    @Test
+    fun emptyProcessesWritesEmptyObject() {
+        val out = temp.newFile("statsTestTasks.json")
+        OutputReport(out).write(emptyMap(), emptyMap(), Stats())
+        assert(out.readText() == "{}")
+    }
+
+    @Test
+    fun nonEmptyProcessesWritesOutputDocumentShape() {
+        val out = temp.newFile("statsTestTasks.json")
+        val processes = mapOf(
+            10L to TestProcess(task = ":a:test", executor = "E1", max = "512m")
+        )
+        val runtimeStats = mapOf(
+            10L to WorkerRuntimeStats(
+                pid = 10L,
+                uptimeMs = 60_000,
+                cpuTimeMs = 30_000,
+                usedHeapBytes = 100_000_000,
+                peakHeapBytes = 200_000_000,
+                peakMetaspaceBytes = 50_000_000,
+                maxHeapBytes = 536_870_912,
+                gcCollections = 2,
+                gcTimeMs = 50,
+                gcType = "G1",
+                jitTimeMs = 400,
+                classesLoaded = 2_500,
+                peakThreads = 12
+            )
+        )
+
+        OutputReport(out).write(processes, runtimeStats, Stats(totalProcesses = 1))
+
+        val body = out.readText()
+        assert(body.contains("\"summary\""))
+        assert(body.contains("\"byTask\""))
+        assert(body.contains("\"workers\""))
+        assert(body.contains("\"tags\""))
+
+        val doc = Json.decodeFromString(OutputDocument.serializer(), body)
+        assert(doc.workers.size == 1)
+        assert(doc.workers.single().pid == 10L)
+        assert(doc.workers.single().task == ":a:test")
+        assert(doc.summary.workers.count == 1)
+        assert(doc.byTask.containsKey(":a:test"))
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

OutputReport implements Report and takes a BuildScanData sink, but never uses it. StatsBuildService.close() therefore passes a no-op JsonValue() only to satisfy the shared signature, coupling file-document persistence to the Develocity/Build Scan port in Report.kt, OutputReport.kt, StatsBuildService.kt, and JsonValue.kt.

### Why this matters

The shared Report port hides that JSON-file and Build Scan outputs are different adapters. The JsonValue null object invites mistaken “report wiring” changes and blocks unit-testing OutputReport without inventing a fake BuildScanData.

### Proposed change

Stop implementing Report on OutputReport; give it a dedicated write/extracted method that accepts only processes, runtimeStats, and stats (and writes OutputDocument). Update StatsBuildService to call that API without JsonValue, and delete JsonValue. Leave BuildScanReport + BuildScanData as the Develocity-only port.

### Notes

Clean-architecture ports: BuildScanData is the outbound port for scan custom values/tags; file output is a separate adapter writing a document. Forcing both through Report violates ISP and blurs the reporting boundary without buying shared behavior beyond mapping already done in ReportJson/Aggregator.

Fixes #104

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/report/JsonValue.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/report/OutputReport.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/report/OutputReportTest.kt`

## Verification

- `./gradlew test`
