### PR TITLE
fix: increase coverage e2e tests for gradle and jdk

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,3 +123,84 @@ jobs:
                   ../../gradlew test -Dorg.gradle.unsafe.isolated-projects=true 2>&1 | tee "$log"
                   grep -q "Configuration cache entry reused" "$log" \
                       || { echo "::error::IP second build did not reuse CC"; exit 1; }
+
+    compatibility:
+        needs: prBranch
+        name: "${{ matrix.project }} / Gradle ${{ matrix.gradle }} / JDK ${{ matrix.java }}"
+        timeout-minutes: 30
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    # Minimum supported Gradle
+                    - project: e2e/consumer
+                      gradle: "8.0.2"
+                      java: "17"
+
+                    # Latest Gradle 8.x
+                    - project: e2e/consumer
+                      gradle: "8.14.3"
+                      java: "17"
+
+                    - project: e2e/consumer
+                      gradle: "8.14.3"
+                      java: "21"
+
+                    # Current Gradle
+                    - project: e2e/consumer
+                      gradle: "9.7.1"
+                      java: "17"
+
+                    - project: e2e/consumer
+                      gradle: "9.7.1"
+                      java: "21"
+
+                    - project: e2e/consumer
+                      gradle: "9.7.1"
+                      java: "25"
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v7
+
+            # Build/publish the plugin itself with its required JDK 17 toolchain
+            - name: Setup JDK 17 for plugin build
+              uses: actions/setup-java@v6
+              with:
+                  distribution: temurin
+                  java-version: 17
+
+            - name: Publish plugin to mavenLocal
+              run: ./gradlew publishToMavenLocal
+
+            # Now switch to the JDK we actually want to test
+            - name: Setup JDK ${{ matrix.java }}
+              uses: actions/setup-java@v6
+              with:
+                  distribution: temurin
+                  java-version: ${{ matrix.java }}
+
+            - name: Setup Gradle ${{ matrix.gradle }}
+              uses: gradle/actions/setup-gradle@v6
+              with:
+                  gradle-version: ${{ matrix.gradle }}
+
+            - name: Test consumer
+              working-directory: ${{ matrix.project }}
+              run: gradle test --configuration-cache
+
+            - name: Verify InfoTestProcess output
+              working-directory: ${{ matrix.project }}
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  test -f build/info-test-process/statsTestTasks.json \
+                      || {
+                          echo "::error::statsTestTasks.json was not generated"
+                          exit 1
+                      }
+
+                  echo "OK — Gradle ${{ matrix.gradle }} / JDK ${{ matrix.java }}"

--- a/src/test/kotlin/io/github/cdsap/testprocess/CompatibilityWorkflowTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/CompatibilityWorkflowTest.kt
@@ -1,0 +1,48 @@
+package io.github.cdsap.testprocess
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CompatibilityWorkflowTest {
+    @Test
+    fun compatibilityJobMatrixUsesExplicitIncludeCombinations() {
+        val workflow = File(".github/workflows/build.yaml").readText()
+
+        assertTrue(
+            "compatibility job must exist in CI workflow",
+            workflow.contains("\n    compatibility:")
+        )
+
+        val entries = parseMatrixInclude(workflow)
+        assertEquals(
+            listOf(
+                MatrixEntry("e2e/consumer", "8.0.2", "17"),
+                MatrixEntry("e2e/consumer", "8.14.3", "17"),
+                MatrixEntry("e2e/consumer", "8.14.3", "21"),
+                MatrixEntry("e2e/consumer", "9.7.1", "17"),
+                MatrixEntry("e2e/consumer", "9.7.1", "21"),
+                MatrixEntry("e2e/consumer", "9.7.1", "25"),
+            ),
+            entries
+        )
+    }
+
+    private data class MatrixEntry(val project: String, val gradle: String, val java: String)
+
+    private fun parseMatrixInclude(workflow: String): List<MatrixEntry> {
+        val compatibilityBlock = workflow.substringAfter("\n    compatibility:")
+        val includeBlock = compatibilityBlock.substringAfter("include:").substringBefore("runs-on:")
+        val entryPattern = Regex(
+            """- project: (\S+)\s+gradle: "([^"]+)"\s+java: "([^"]+)""""
+        )
+        return entryPattern.findAll(includeBlock).map { match ->
+            MatrixEntry(
+                project = match.groupValues[1],
+                gradle = match.groupValues[2],
+                java = match.groupValues[3]
+            )
+        }.toList()
+    }
+}


### PR DESCRIPTION
## Summary

Right now all jobs use JDK 17, and the E2E tests ultimately use the root Gradle wrapper, which is Gradle 9.7.1.

Your documented support is **Gradle 8+** and **test workers on JDK 17+**, so I’d add a dedicated compatibility matrix rather than expanding every existing job.

I recommend this:

Fixes #107

## Changes

- `.github/workflows/build.yaml`
- `src/test/kotlin/io/github/cdsap/testprocess/CompatibilityWorkflowTest.kt`

## Verification

- `./gradlew test`
