### PR TITLE
fix: update extension to opt-out reporting to develocity

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/DevelocityReporting.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/DevelocityReporting.kt
@@ -1,0 +1,31 @@
+package io.github.cdsap.testprocess
+
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+
+/**
+ * Gradle property names and resolution rules for legacy Develocity reporting.
+ *
+ * When the Develocity plugin is applied, reporting to the Build Scan is enabled by
+ * default. Set [PROPERTY_ENABLED]=false to opt out and write [statsTestTasks.json]
+ * instead.
+ */
+internal object DevelocityReporting {
+    const val PROPERTY_ENABLED = "infoTestProcess.develocity.enabled"
+
+    fun reportToDevelocity(develocityOnClasspath: Boolean, enabled: Boolean): Boolean =
+        develocityOnClasspath && enabled
+
+    fun configureConventions(
+        extension: DevelocityReportingExtension,
+        providers: ProviderFactory,
+        develocityOnClasspath: Boolean
+    ) {
+        extension.enabled.convention(
+            optionalBooleanProperty(providers, PROPERTY_ENABLED).orElse(develocityOnClasspath)
+        )
+    }
+
+    private fun optionalBooleanProperty(providers: ProviderFactory, name: String): Provider<Boolean> =
+        providers.gradleProperty(name).map { it.toBoolean() }
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt
@@ -11,11 +11,26 @@ import javax.inject.Inject
  * Prefer Gradle properties for CI opt-in; the DSL mirrors the same flags.
  */
 abstract class InfoTestProcessExtension @Inject constructor(objects: ObjectFactory) {
+    val develocity: DevelocityReportingExtension =
+        objects.newInstance(DevelocityReportingExtension::class.java)
     val gbos: GbosExtension = objects.newInstance(GbosExtension::class.java)
+
+    fun develocity(action: Action<in DevelocityReportingExtension>) {
+        action.execute(develocity)
+    }
 
     fun gbos(action: Action<in GbosExtension>) {
         action.execute(gbos)
     }
+}
+
+/**
+ * Legacy Build Scan reporting. When the Develocity plugin is applied, reporting is
+ * enabled by default; set [DevelocityReportingExtension.enabled] to false to write
+ * `statsTestTasks.json` instead.
+ */
+abstract class DevelocityReportingExtension {
+    abstract val enabled: Property<Boolean>
 }
 
 /**

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -20,11 +20,17 @@ import org.gradle.process.CommandLineArgumentProvider
 class InfoTestProcessPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
         val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
-        val gbos = target.extensions.create(
+        val develocityOnClasspath = develocityConfiguration != null
+        val infoTestProcess = target.extensions.create(
             "infoTestProcess",
             InfoTestProcessExtension::class.java
-        ).gbos
-        GbosOptIn.configureConventions(gbos, target.providers)
+        )
+        DevelocityReporting.configureConventions(
+            infoTestProcess.develocity,
+            target.providers,
+            develocityOnClasspath
+        )
+        GbosOptIn.configureConventions(infoTestProcess.gbos, target.providers)
 
         // Populated by the rootProject {} action below, which runs when the root project is
         // instantiated — before any project (including the root) is configured, so the
@@ -59,17 +65,22 @@ class InfoTestProcessPlugin : Plugin<Settings> {
                 parameters.pathGbosNdjson = gbosNdjson.map { it.asFile }
                 parameters.registryDir = registryDir.map { it.asFile }
                 parameters.agentJar = agentJar.map { it.asFile }
-                parameters.develocity = providers.provider { develocityConfiguration != null }
-                parameters.gbosJsonOutput = gbos.json
-                parameters.gbosNdjsonOutput = gbos.ndjson
+                parameters.develocity = providers.provider {
+                    DevelocityReporting.reportToDevelocity(
+                        develocityOnClasspath,
+                        infoTestProcess.develocity.enabled.get()
+                    )
+                }
+                parameters.gbosJsonOutput = infoTestProcess.gbos.json
+                parameters.gbosNdjsonOutput = infoTestProcess.gbos.ndjson
             }
 
             val persistedStateProvider = providers.of(PersistedDeserializationValueSource::class) {
                 parameters.file.set(persistedTxt)
             }
-            if (develocityConfiguration != null) {
-                BuildScanReport(gbos.develocity.get())
-                    .develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
+            if (develocityOnClasspath && infoTestProcess.develocity.enabled.get()) {
+                BuildScanReport(infoTestProcess.gbos.develocity.get())
+                    .develocityBuildScanReporting(develocityConfiguration!!, persistedStateProvider)
             }
 
             wireProject = { project ->

--- a/src/test/kotlin/io/github/cdsap/testprocess/DevelocityReportingTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/DevelocityReportingTest.kt
@@ -1,0 +1,23 @@
+package io.github.cdsap.testprocess
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DevelocityReportingTest {
+    @Test
+    fun reportsToDevelocityWhenPluginIsAppliedAndReportingIsEnabled() {
+        assertTrue(DevelocityReporting.reportToDevelocity(develocityOnClasspath = true, enabled = true))
+    }
+
+    @Test
+    fun optsOutToFileWhenReportingIsDisabledEvenWithDevelocityApplied() {
+        assertFalse(DevelocityReporting.reportToDevelocity(develocityOnClasspath = true, enabled = false))
+    }
+
+    @Test
+    fun reportsToFileWhenDevelocityIsNotApplied() {
+        assertFalse(DevelocityReporting.reportToDevelocity(develocityOnClasspath = false, enabled = true))
+        assertFalse(DevelocityReporting.reportToDevelocity(develocityOnClasspath = false, enabled = false))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/testprocess/IntegrationDvOptOutTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/IntegrationDvOptOutTest.kt
@@ -1,0 +1,120 @@
+package io.github.cdsap.testprocess
+
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class IntegrationDvOptOutTest {
+    @Rule
+    @JvmField
+    val testProjectDir = TemporaryFolder()
+
+    @Test
+    fun develocityOptOutWritesJsonInsteadOfBuildScanPersistence() {
+        createProject(
+            extraGradleProperties = "infoTestProcess.develocity.enabled=false"
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("test", "--configuration-cache")
+            .withPluginClasspath()
+            .withGradleVersion("9.7.1")
+            .build()
+
+        val json = File("${testProjectDir.root}/build/info-test-process/statsTestTasks.json")
+        val txt = File("${testProjectDir.root}/build/info-test-process/statsTestTasks.txt")
+        assertTrue(json.exists())
+        assertFalse(txt.exists())
+        val body = json.readText()
+        assertTrue(body.contains("\"summary\""))
+        assertTrue(body.contains("\"byTask\""))
+        assertTrue(body.contains("\"workers\""))
+        assertTrue(body.contains("\"tags\""))
+    }
+
+    @Test
+    fun develocityExtensionDslCanOptOutOfBuildScanReporting() {
+        createProject(
+            settingsExtra = """
+                    infoTestProcess {
+                        develocity {
+                            enabled = false
+                        }
+                    }
+            """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("test", "--configuration-cache")
+            .withPluginClasspath()
+            .withGradleVersion("9.7.1")
+            .build()
+
+        assertTrue(File("${testProjectDir.root}/build/info-test-process/statsTestTasks.json").exists())
+        assertFalse(File("${testProjectDir.root}/build/info-test-process/statsTestTasks.txt").exists())
+    }
+
+    private fun createProject(
+        extraGradleProperties: String = "",
+        settingsExtra: String = ""
+    ) {
+        testProjectDir.newFile("settings.gradle").appendText(
+            """
+                plugins {
+                    id 'com.gradle.develocity' version '4.1'
+                    id 'io.github.cdsap.testprocess'
+                }
+                develocity {
+                    server = "https://example.invalid"
+                    buildScan {
+                        publishing.onlyIf { false }
+                    }
+                }
+                $settingsExtra
+            """.trimIndent()
+        )
+        testProjectDir.newFile("gradle.properties").appendText(
+            """
+                kotlin.internal.collectFUSMetrics=false
+                $extraGradleProperties
+            """.trimIndent()
+        )
+        testProjectDir.newFile("build.gradle").appendText(
+            """
+                plugins {
+                    id 'org.jetbrains.kotlin.jvm' version '2.2.0'
+                    id 'application'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    testImplementation("org.jetbrains.kotlin:kotlin-test:2.2.20")
+                }
+            """.trimIndent()
+        )
+        val testPkgDir = File(testProjectDir.root, "src/test/kotlin/com/example")
+        testPkgDir.mkdirs()
+        File("${testPkgDir.path}/SamplePluginTest.kt").writeText(
+            """
+            package com.example
+
+            import kotlin.test.Test
+            import kotlin.test.assertTrue
+
+            class SamplePluginTest {
+                @Test
+                fun `smoke test runs`() {
+                    assertTrue(1 + 1 == 2)
+                }
+            }
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Update extension to Opt-out reporting to Develocity, now we are checking if Develocity extension is included in the classpath to enable it, this is the default behavior but we need to have the option to opt-out and report to file

Fixes #109

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/DevelocityReporting.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/GbosExtension.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/DevelocityReportingTest.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/IntegrationDvOptOutTest.kt`

## Verification

- `./gradlew test`
