### PR TITLE
fix: develocity-gradle-plugin leaks into the published pom as a runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.plugin.compatibility.compatibility
+import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
 
 plugins {
     `java-gradle-plugin`
@@ -24,10 +25,26 @@ sourceSets {
     }
 }
 
+val develocityPluginClasspath by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
 dependencies {
-    implementation("com.gradle:develocity-gradle-plugin:4.5.0")
+    compileOnly("com.gradle:develocity-gradle-plugin:4.5.0")
+    develocityPluginClasspath("com.gradle:develocity-gradle-plugin:4.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     testImplementation("junit:junit:4.13.2")
+}
+
+tasks.test {
+    dependsOn("generatePomFileForPluginMavenPublication")
+}
+
+tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
+    // compileOnly keeps Develocity out of the published POM; TestKit still needs it
+    // on the plugin classpath when integration tests exercise the Develocity path.
+    pluginClasspath.from(develocityPluginClasspath)
 }
 
 val agentJar = tasks.register<Jar>("agentJar") {

--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.testprocess
 
-import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.testprocess.report.BuildScanReport
 import io.github.cdsap.testprocess.service.StatsBuildService
 import org.gradle.api.Plugin
@@ -19,7 +18,7 @@ import org.gradle.process.CommandLineArgumentProvider
 
 class InfoTestProcessPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
-        val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
+        val develocityConfiguration = target.extensions.findByName("develocity")
         val gbos = target.extensions.create(
             "infoTestProcess",
             InfoTestProcessExtension::class.java
@@ -68,8 +67,12 @@ class InfoTestProcessPlugin : Plugin<Settings> {
                 parameters.file.set(persistedTxt)
             }
             if (develocityConfiguration != null) {
+                @Suppress("UNCHECKED_CAST")
                 BuildScanReport(gbos.develocity.get())
-                    .develocityBuildScanReporting(develocityConfiguration, persistedStateProvider)
+                    .develocityBuildScanReporting(
+                        develocityConfiguration as com.gradle.develocity.agent.gradle.DevelocityConfiguration,
+                        persistedStateProvider
+                    )
             }
 
             wireProject = { project ->

--- a/src/test/kotlin/io/github/cdsap/testprocess/PublishedPomTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/PublishedPomTest.kt
@@ -1,0 +1,20 @@
+package io.github.cdsap.testprocess
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+class PublishedPomTest {
+    @Test
+    fun pluginMavenPomDoesNotDeclareDevelocityRuntimeDependency() {
+        val pom = File("build/publications/pluginMaven/pom-default.xml")
+        assert(pom.isFile) {
+            "expected ${pom.path} — run generatePomFileForPluginMavenPublication before test"
+        }
+        val xml = pom.readText()
+        assertFalse(
+            "develocity-gradle-plugin must not appear in the published plugin POM",
+            xml.contains("develocity-gradle-plugin")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`develocity-gradle-plugin` is declared as `implementation`:

`build.gradle.kts:28`
```kotlin
implementation("com.gradle:develocity-gradle-plugin:4.5.0")
```

so it lands in the published POM as a `runtime` dependency. From the generated `build/publications/pluginMaven/pom-default.xml`:

```xml
<dependency>
  <groupId>com.gradle</groupId>
  <artifactId>develocity-gradle-plugin</artifactId>
  <version>4.5.0</version>
  <scope>runtime</scope>
</dependency>
```

But the plugin treats Develocity as strictly **optional** everywhere it is touched:

`src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt:22`
```kotlin
val develocityConfiguration = target.extensions.findByType(DevelocityConfiguration::class.java)
```

with null-guarded branches at `:73` and a `parameters.develocity` flag derived from `develocityConfiguration != null`. Nothing requires it at runtime.

Fixes #116

## Changes

- `build.gradle.kts`
- `src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/PublishedPomTest.kt`

## Verification

- `./gradlew test`
