### PR TITLE
fix: statsbuildservice shared mutable state is not thread-safe under par

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt
@@ -103,7 +103,7 @@ class InfoTestProcessPlugin : Plugin<Settings> {
             addTestListener(object : TestListener {
                 override fun beforeSuite(suite: TestDescriptor?) {
                     if (isGradleExecutor(suite?.name)) {
-                        service.get().stats.totalProcesses++
+                        service.get().stats.incrementTotalProcesses()
                     }
                 }
                 override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {}

--- a/src/main/kotlin/io/github/cdsap/testprocess/model/Stats.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/model/Stats.kt
@@ -8,4 +8,9 @@ data class Stats(
     var tasksWithoutProcess: Int = 0,
     var statsSnapshotsCaptured: Int = 0,
     var statsSnapshotsMissing: Int = 0
-)
+) {
+    @Synchronized
+    fun incrementTotalProcesses() {
+        totalProcesses++
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
@@ -15,6 +15,7 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationCompletionListener
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, AutoCloseable,
     OperationCompletionListener {
@@ -30,7 +31,7 @@ abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, A
         var gbosNdjsonOutput: Provider<Boolean>
     }
 
-    val processes = mutableMapOf<Long, TestProcess>()
+    val processes = ConcurrentHashMap<Long, TestProcess>()
     val stats = Stats()
 
     init {

--- a/src/test/kotlin/io/github/cdsap/testprocess/model/StatsTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/model/StatsTest.kt
@@ -1,0 +1,36 @@
+package io.github.cdsap.testprocess.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class StatsTest {
+
+    @Test
+    fun incrementsTotalProcessesSafelyFromConcurrentCallbacks() {
+        val stats = Stats()
+        val workers = 16
+        val incrementsPerWorker = 1_000
+        val ready = CountDownLatch(workers)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(workers)
+        val executor = Executors.newFixedThreadPool(workers)
+
+        repeat(workers) {
+            executor.submit {
+                ready.countDown()
+                start.await()
+                repeat(incrementsPerWorker) { stats.incrementTotalProcesses() }
+                done.countDown()
+            }
+        }
+
+        ready.await()
+        start.countDown()
+        done.await()
+        executor.shutdown()
+
+        assertEquals(workers * incrementsPerWorker, stats.totalProcesses)
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`StatsBuildService` holds unsynchronized mutable state that is written from test-execution callbacks:

`src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt:33-34`
```kotlin
val processes = mutableMapOf<Long, TestProcess>()
val stats = Stats()
```

`src/main/kotlin/io/github/cdsap/testprocess/model/Stats.kt:6`
```kotlin
@Serializable
data class Stats(
    var totalProcesses: Int = 0,
    var tasksWithoutProcess: Int = 0,
    var statsSnapshotsCaptured: Int = 0,
    var statsSnapshotsMissing: Int = 0
)
```

and the increment happens inside a `TestListener` attached to every `Test` task:

`src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt:104-108`
```kotlin
override fun beforeSuite(suite: TestDescriptor?) {
    if (isGradleExecutor(suite?.name)) {
        service.get().stats.totalProcesses++
    }
}
```

Fixes #118

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/InfoTestProcessPlugin.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/model/Stats.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/model/StatsTest.kt`

## Verification

- `./gradlew test`
