### PR TITLE
fix: refactor workerstatecollector to separate file storage from state a

### DIFF
--- a/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt
@@ -4,19 +4,19 @@ import io.github.cdsap.testprocess.model.PersistedState
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
 import io.github.cdsap.testprocess.model.WorkerRuntimeStats
-import java.io.File
 
 object WorkerStateCollector {
     fun collect(
-        registryDir: File,
+        registryEntries: Collection<WorkerRegistryEntry>,
+        runtimeStatsEntries: Collection<WorkerRuntimeStats>,
         processes: MutableMap<Long, TestProcess>,
         stats: Stats
     ): PersistedState {
-        WorkerRegistry.read(registryDir).forEach { entry ->
+        registryEntries.forEach { entry ->
             processes.putIfAbsent(entry.pid, WorkerIdentityMapper.toTestProcess(entry))
         }
         val runtimeStats: Map<Long, WorkerRuntimeStats> =
-            WorkerRegistry.readStats(registryDir).associateBy { it.pid }
+            runtimeStatsEntries.associateBy { it.pid }
         stats.statsSnapshotsCaptured = runtimeStats.size
         stats.statsSnapshotsMissing = processes.keys.count { it !in runtimeStats }
         return PersistedState(processes, runtimeStats, stats)

--- a/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt
@@ -47,7 +47,12 @@ abstract class StatsBuildService : BuildService<StatsBuildService.Parameters>, A
 
     override fun close() {
         val registry = parameters.registryDir.get()
-        val payload = WorkerStateCollector.collect(registry, processes, stats)
+        val payload = WorkerStateCollector.collect(
+            WorkerRegistry.read(registry),
+            WorkerRegistry.readStats(registry),
+            processes,
+            stats
+        )
         if (parameters.develocity.get()) {
             val output = parameters.path.get()
             output.parentFile?.mkdirs()

--- a/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt
@@ -2,33 +2,49 @@ package io.github.cdsap.testprocess.agent
 
 import io.github.cdsap.testprocess.model.Stats
 import io.github.cdsap.testprocess.model.TestProcess
-import org.junit.Rule
+import io.github.cdsap.testprocess.model.WorkerRuntimeStats
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
 
 class WorkerStateCollectorTest {
-    @Rule
-    @JvmField
-    val tmp = TemporaryFolder()
-
     @Test
     fun collectsStateWithCapturedAndMissingSnapshots() {
-        val dir = tmp.newFolder("workers")
-        File(dir, "10.json").writeText(
-            """{"pid":10,"task":":app:test","executor":"Gradle Test Executor 1","maxHeapBytes":536870912,"startMs":1,"args":[]}"""
+        val registryEntries = listOf(
+            WorkerRegistryEntry(
+                pid = 10,
+                task = ":app:test",
+                executor = "Gradle Test Executor 1",
+                maxHeapBytes = 536870912,
+                startMs = 1
+            ),
+            WorkerRegistryEntry(
+                pid = 20,
+                task = ":lib:test",
+                executor = "Gradle Test Executor 2",
+                maxHeapBytes = 1073741824,
+                startMs = 2
+            )
         )
-        File(dir, "10.stats.json").writeText(
-            """{"pid":10,"uptimeMs":12000,"cpuTimeMs":3400,"usedHeapBytes":104857600,"peakHeapBytes":209715200,"peakMetaspaceBytes":52428800,"maxHeapBytes":536870912,"gcCollections":4,"gcTimeMs":120,"gcType":"G1","jitTimeMs":850,"classesLoaded":4823,"peakThreads":18}"""
+        val runtimeStatsEntries = listOf(
+            WorkerRuntimeStats(
+                pid = 10,
+                uptimeMs = 12000,
+                cpuTimeMs = 3400,
+                usedHeapBytes = 104857600,
+                peakHeapBytes = 209715200,
+                peakMetaspaceBytes = 52428800,
+                maxHeapBytes = 536870912,
+                gcCollections = 4,
+                gcTimeMs = 120,
+                gcType = "G1",
+                jitTimeMs = 850,
+                classesLoaded = 4823,
+                peakThreads = 18
+            )
         )
-        File(dir, "20.json").writeText(
-            """{"pid":20,"task":":lib:test","executor":"Gradle Test Executor 2","maxHeapBytes":1073741824,"startMs":2,"args":[]}"""
-        )
-        // Worker 20 has identity but no .stats.json snapshot.
 
         val processes = mutableMapOf<Long, TestProcess>()
         val stats = Stats(totalProcesses = 2)
-        val state = WorkerStateCollector.collect(dir, processes, stats)
+        val state = WorkerStateCollector.collect(registryEntries, runtimeStatsEntries, processes, stats)
 
         assert(state.processes.size == 2)
         assert(state.processes[10L]?.task == ":app:test")
@@ -48,15 +64,20 @@ class WorkerStateCollectorTest {
 
     @Test
     fun doesNotOverwriteExistingProcessEntries() {
-        val dir = tmp.newFolder("workers")
-        File(dir, "5.json").writeText(
-            """{"pid":5,"task":":from:registry","executor":"Registry Executor","maxHeapBytes":268435456,"startMs":1,"args":[]}"""
+        val registryEntries = listOf(
+            WorkerRegistryEntry(
+                pid = 5,
+                task = ":from:registry",
+                executor = "Registry Executor",
+                maxHeapBytes = 268435456,
+                startMs = 1
+            )
         )
         val existing = TestProcess(task = ":already:tracked", executor = "Existing", max = "256m")
         val processes = mutableMapOf(5L to existing)
         val stats = Stats()
 
-        val state = WorkerStateCollector.collect(dir, processes, stats)
+        val state = WorkerStateCollector.collect(registryEntries, emptyList(), processes, stats)
 
         assert(state.processes[5L] === existing)
         assert(state.processes[5L]?.task == ":already:tracked")
@@ -66,16 +87,24 @@ class WorkerStateCollectorTest {
 
     @Test
     fun mapsHeapBytesAndMissingExecutorFallback() {
-        val dir = tmp.newFolder("workers")
-        File(dir, "7.json").writeText(
-            """{"pid":7,"task":":a:test","maxHeapBytes":536870912,"startMs":1,"args":[]}"""
-        )
-        File(dir, "8.json").writeText(
-            """{"pid":8,"task":":b:test","executor":"Gradle Test Executor 2","maxHeapBytes":1073741824,"startMs":2,"args":[]}"""
+        val registryEntries = listOf(
+            WorkerRegistryEntry(
+                pid = 7,
+                task = ":a:test",
+                maxHeapBytes = 536870912,
+                startMs = 1
+            ),
+            WorkerRegistryEntry(
+                pid = 8,
+                task = ":b:test",
+                executor = "Gradle Test Executor 2",
+                maxHeapBytes = 1073741824,
+                startMs = 2
+            )
         )
 
         val processes = mutableMapOf<Long, TestProcess>()
-        val state = WorkerStateCollector.collect(dir, processes, Stats())
+        val state = WorkerStateCollector.collect(registryEntries, emptyList(), processes, Stats())
 
         assert(state.processes[7L]?.executor == "Gradle Test Executor pid-7")
         assert(state.processes[7L]?.max == "512m")


### PR DESCRIPTION
## Summary

### Problem

WorkerStateCollector directly depends on WorkerRegistry and File, reading and deserializing worker files before assembling PersistedState (src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt:9-22).

### Why this matters

The state-aggregation boundary is coupled to filesystem infrastructure, making the core behavior harder to test independently and tying future storage changes to aggregation logic.

### Proposed change

Make WorkerStateCollector.collect accept decoded WorkerRegistryEntry and WorkerRuntimeStats collections. Let StatsBuildService read those collections through WorkerRegistry before invoking the collector. Update collector tests to use in-memory inputs while keeping file-format coverage in WorkerRegistryTest.

### Notes

This is a small clean-architecture boundary improvement: WorkerRegistry acts as the infrastructure adapter, while WorkerStateCollector contains storage-independent domain assembly logic.

Fixes #114

## Changes

- `src/main/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollector.kt`
- `src/main/kotlin/io/github/cdsap/testprocess/service/StatsBuildService.kt`
- `src/test/kotlin/io/github/cdsap/testprocess/agent/WorkerStateCollectorTest.kt`

## Verification

- `./gradlew test`
